### PR TITLE
Refactor KV iterators

### DIFF
--- a/abft/common_test.go
+++ b/abft/common_test.go
@@ -2,6 +2,7 @@ package abft
 
 import (
 	"fmt"
+
 	"github.com/Fantom-foundation/lachesis-base/hash"
 	"github.com/Fantom-foundation/lachesis-base/inter/idx"
 	"github.com/Fantom-foundation/lachesis-base/inter/pos"

--- a/abft/frame_decide_test.go
+++ b/abft/frame_decide_test.go
@@ -91,7 +91,7 @@ func testConfirmBlocks(t *testing.T, weights []pos.Weight, cheatersCount int) {
 	})
 
 	// unconfirm all events
-	it := lch.store.epochTable.ConfirmedEvent.NewIterator()
+	it := lch.store.epochTable.ConfirmedEvent.NewIterator(nil, nil)
 	batch := lch.store.epochTable.ConfirmedEvent.NewBatch()
 	for it.Next() {
 		assertar.NoError(batch.Delete(it.Key()))

--- a/abft/indexed_lachesis.go
+++ b/abft/indexed_lachesis.go
@@ -1,6 +1,8 @@
 package abft
 
 import (
+	"math/big"
+
 	"github.com/Fantom-foundation/lachesis-base/abft/dagidx"
 	"github.com/Fantom-foundation/lachesis-base/hash"
 	"github.com/Fantom-foundation/lachesis-base/inter/dag"
@@ -9,7 +11,6 @@ import (
 	"github.com/Fantom-foundation/lachesis-base/kvdb"
 	"github.com/Fantom-foundation/lachesis-base/lachesis"
 	"github.com/ethereum/go-ethereum/common"
-	"math/big"
 )
 
 var _ lachesis.Consensus = (*IndexedLachesis)(nil)

--- a/abft/restart_test.go
+++ b/abft/restart_test.go
@@ -127,7 +127,7 @@ func testRestart(t *testing.T, weights []pos.Weight, cheatersCount int) {
 			store := NewMemStore()
 			// copy prev DB into new one
 			{
-				it := prev.store.mainDB.NewIterator()
+				it := prev.store.mainDB.NewIterator(nil, nil)
 				defer it.Release()
 				for it.Next() {
 					assertar.NoError(store.mainDB.Put(it.Key(), it.Value()))
@@ -135,7 +135,7 @@ func testRestart(t *testing.T, weights []pos.Weight, cheatersCount int) {
 			}
 			restartEpochDB := memorydb.New()
 			{
-				it := prev.store.epochDB.NewIterator()
+				it := prev.store.epochDB.NewIterator(nil, nil)
 				for it.Next() {
 					assertar.NoError(restartEpochDB.Put(it.Key(), it.Value()))
 				}

--- a/abft/store_roots.go
+++ b/abft/store_roots.go
@@ -61,7 +61,7 @@ func (s *Store) GetFrameRoots(f idx.Frame) []election.RootAndSlot {
 	}
 	rr := make([]election.RootAndSlot, 0, 100)
 
-	it := s.epochTable.Roots.NewIteratorWithPrefix(f.Bytes())
+	it := s.epochTable.Roots.NewIterator(f.Bytes(), nil)
 	defer it.Release()
 	for it.Next() {
 		key := it.Key()

--- a/emitter/ancestor/parents.go
+++ b/emitter/ancestor/parents.go
@@ -15,7 +15,7 @@ type SearchStrategy interface {
 // FindBestParents returns estimated parents subset, according to provided strategy
 // max is max num of parents to link with (including self-parent)
 // returns set of parents to link, len(res) <= max
-func FindBestParents(max int, options hash.Events, selfParent *hash.Event, strategy SearchStrategy) (*hash.Event, hash.Events) {
+func FindBestParents(max uint32, options hash.Events, selfParent *hash.Event, strategy SearchStrategy) (*hash.Event, hash.Events) {
 	optionsSet := options.Set()
 	parents := make(hash.Events, 0, max)
 	if selfParent != nil {
@@ -25,7 +25,7 @@ func FindBestParents(max int, options hash.Events, selfParent *hash.Event, strat
 
 	strategy.Init(selfParent)
 
-	for len(parents) < max && len(optionsSet) > 0 {
+	for uint32(len(parents)) < max && len(optionsSet) > 0 {
 		best := strategy.Find(optionsSet.Slice())
 		parents = append(parents, best)
 		optionsSet.Erase(best)

--- a/emitter/ancestor/parents_test.go
+++ b/emitter/ancestor/parents_test.go
@@ -1,7 +1,6 @@
 package ancestor
 
 import (
-	"github.com/Fantom-foundation/lachesis-base/utils/adapters"
 	"sort"
 	"strconv"
 	"strings"
@@ -16,6 +15,7 @@ import (
 	"github.com/Fantom-foundation/lachesis-base/inter/pos"
 	"github.com/Fantom-foundation/lachesis-base/kvdb/memorydb"
 	"github.com/Fantom-foundation/lachesis-base/utils"
+	"github.com/Fantom-foundation/lachesis-base/utils/adapters"
 	"github.com/Fantom-foundation/lachesis-base/vecfc"
 )
 

--- a/emitter/ancestor/vector_clock.go
+++ b/emitter/ancestor/vector_clock.go
@@ -1,9 +1,9 @@
 package ancestor
 
 import (
-	"github.com/Fantom-foundation/lachesis-base/abft/dagidx"
 	"sort"
 
+	"github.com/Fantom-foundation/lachesis-base/abft/dagidx"
 	"github.com/Fantom-foundation/lachesis-base/hash"
 	"github.com/Fantom-foundation/lachesis-base/inter/idx"
 	"github.com/Fantom-foundation/lachesis-base/inter/pos"

--- a/gossip/ordering/event_buffer.go
+++ b/gossip/ordering/event_buffer.go
@@ -1,7 +1,7 @@
 package ordering
 
 import (
-	"github.com/hashicorp/golang-lru"
+	lru "github.com/hashicorp/golang-lru"
 
 	"github.com/Fantom-foundation/lachesis-base/eventcheck"
 	"github.com/Fantom-foundation/lachesis-base/hash"

--- a/gossip/ordering/ordering_test.go
+++ b/gossip/ordering/ordering_test.go
@@ -2,7 +2,6 @@ package ordering
 
 import (
 	"errors"
-	"github.com/Fantom-foundation/lachesis-base/inter/idx"
 	"math/rand"
 	"testing"
 	"time"
@@ -10,6 +9,7 @@ import (
 	"github.com/Fantom-foundation/lachesis-base/hash"
 	"github.com/Fantom-foundation/lachesis-base/inter/dag"
 	"github.com/Fantom-foundation/lachesis-base/inter/dag/tdag"
+	"github.com/Fantom-foundation/lachesis-base/inter/idx"
 )
 
 func TestEventBuffer(t *testing.T) {

--- a/kvdb/devnulldb/devnulldb.go
+++ b/kvdb/devnulldb/devnulldb.go
@@ -1,6 +1,8 @@
 package devnulldb
 
-import "github.com/Fantom-foundation/lachesis-base/kvdb"
+import (
+	"github.com/Fantom-foundation/lachesis-base/kvdb"
+)
 
 // Database is an always empty database.
 type Database struct{}
@@ -46,22 +48,10 @@ func (db *Database) NewBatch() kvdb.Batch {
 	return &batch{}
 }
 
-// NewIterator creates a binary-alphabetical iterator over the entire keyspace
-// contained within the memory database.
-func (db *Database) NewIterator() kvdb.Iterator {
-	return &iterator{}
-}
-
-// NewIteratorWithStart creates a binary-alphabetical iterator over a subset of
-// database content starting at a particular initial key (or after, if it does
-// not exist).
-func (db *Database) NewIteratorWithStart(start []byte) kvdb.Iterator {
-	return &iterator{}
-}
-
-// NewIteratorWithPrefix creates a binary-alphabetical iterator over a subset
-// of database content with a particular key prefix.
-func (db *Database) NewIteratorWithPrefix(prefix []byte) kvdb.Iterator {
+// NewIterator creates a binary-alphabetical iterator over a subset
+// of database content with a particular key prefix, starting at a particular
+// initial key (or after, if it does not exist).
+func (db *Database) NewIterator(prefix []byte, start []byte) kvdb.Iterator {
 	return &iterator{}
 }
 

--- a/kvdb/fallible/fallible.go
+++ b/kvdb/fallible/fallible.go
@@ -76,23 +76,11 @@ func (f *Fallible) NewBatch() kvdb.Batch {
 	return f.Underlying.NewBatch()
 }
 
-// NewIterator creates a binary-alphabetical iterator over the entire keyspace
-// contained within the key-value database.
-func (f *Fallible) NewIterator() kvdb.Iterator {
-	return f.Underlying.NewIterator()
-}
-
-// NewIteratorWithStart creates a binary-alphabetical iterator over a subset of
-// database content starting at a particular initial key (or after, if it does
-// not exist).
-func (f *Fallible) NewIteratorWithStart(start []byte) kvdb.Iterator {
-	return f.Underlying.NewIteratorWithStart(start)
-}
-
-// NewIteratorWithPrefix creates a binary-alphabetical iterator over a subset
-// of database content with a particular key prefix.
-func (f *Fallible) NewIteratorWithPrefix(prefix []byte) kvdb.Iterator {
-	return f.Underlying.NewIteratorWithPrefix(prefix)
+// NewIterator creates a binary-alphabetical iterator over a subset
+// of database content with a particular key prefix, starting at a particular
+// initial key (or after, if it does not exist).
+func (f *Fallible) NewIterator(prefix []byte, start []byte) kvdb.Iterator {
+	return f.Underlying.NewIterator(prefix, start)
 }
 
 // Stat returns a particular internal stat of the database.

--- a/kvdb/flushable/flushable.go
+++ b/kvdb/flushable/flushable.go
@@ -389,50 +389,16 @@ func (it *iterator) Release() {
 	*it = iterator{}
 }
 
-// NewIterator creates a binary-alphabetical iterator over the entire keyspace
-// contained within the memory database.
-func (w *Flushable) NewIterator() kvdb.Iterator {
-	w.lock.Lock()
-	defer w.lock.Unlock()
-
+// NewIterator creates a binary-alphabetical iterator over a subset
+// of database content with a particular key prefix, starting at a particular
+// initial key (or after, if it does not exist).
+func (w *Flushable) NewIterator(prefix []byte, start []byte) kvdb.Iterator {
 	it := &iterator{
 		lock:     w.lock,
 		tree:     w.modified,
-		parentIt: w.underlying.NewIterator(),
-	}
-	it.init()
-	return it
-}
-
-// NewIteratorWithStart creates a binary-alphabetical iterator over a subset of
-// database content starting at a particular initial key (or after, if it does
-// not exist).
-func (w *Flushable) NewIteratorWithStart(start []byte) kvdb.Iterator {
-	w.lock.Lock()
-	defer w.lock.Unlock()
-
-	it := &iterator{
-		lock:     w.lock,
-		tree:     w.modified,
-		start:    start,
-		parentIt: w.underlying.NewIteratorWithStart(start),
-	}
-	it.init()
-	return it
-}
-
-// NewIteratorWithPrefix creates a binary-alphabetical iterator over a subset
-// of database content with a particular key prefix.
-func (w *Flushable) NewIteratorWithPrefix(prefix []byte) kvdb.Iterator {
-	w.lock.Lock()
-	defer w.lock.Unlock()
-
-	it := &iterator{
-		lock:     w.lock,
-		tree:     w.modified,
-		start:    prefix,
+		start:    append(common.CopyBytes(prefix), start...),
 		prefix:   prefix,
-		parentIt: w.underlying.NewIteratorWithPrefix(prefix),
+		parentIt: w.underlying.NewIterator(prefix, start),
 	}
 	it.init()
 	return it

--- a/kvdb/flushable/flushable_parallel_test.go
+++ b/kvdb/flushable/flushable_parallel_test.go
@@ -42,7 +42,7 @@ func TestFlushableParallel(t *testing.T) {
 		require := require.New(t)
 
 		// iterate over tableImmutable and check its content
-		it := tableImmutable.NewIterator()
+		it := tableImmutable.NewIterator(nil, nil)
 		defer it.Release()
 
 		_ = flushableDb.Flush() // !breaking flush
@@ -95,7 +95,7 @@ func TestFlushableParallel(t *testing.T) {
 			require := require.New(t)
 			for !stopped() {
 				// iterate over tableImmutable and check its content
-				it := tableImmutable.NewIterator()
+				it := tableImmutable.NewIterator(nil, nil)
 				defer it.Release()
 
 				i := uint64(0)

--- a/kvdb/flushable/flushable_parallel_test.go
+++ b/kvdb/flushable/flushable_parallel_test.go
@@ -132,6 +132,6 @@ func tmpDir() kvdb.DbProducer {
 	if err != nil {
 		panic(fmt.Sprintf("can't create temporary directory %s: %v", dir, err))
 	}
-	disk := leveldb.NewProducer(dir)
+	disk := leveldb.NewProducer(dir, cache16mb)
 	return disk
 }

--- a/kvdb/flushable/flushable_test.go
+++ b/kvdb/flushable/flushable_test.go
@@ -3,7 +3,6 @@ package flushable
 import (
 	"bytes"
 	"fmt"
-	"github.com/syndtr/goleveldb/leveldb/opt"
 	"io/ioutil"
 	"math/big"
 	"math/rand"
@@ -12,6 +11,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/assert"
+	"github.com/syndtr/goleveldb/leveldb/opt"
 
 	"github.com/Fantom-foundation/lachesis-base/kvdb"
 	"github.com/Fantom-foundation/lachesis-base/kvdb/leveldb"
@@ -180,11 +180,11 @@ func TestFlushable(t *testing.T) {
 
 				var it kvdb.Iterator
 				if try%3 == 0 {
-					it = db.NewIterator()
+					it = db.NewIterator(nil, nil)
 				} else if try%3 == 1 {
-					it = db.NewIteratorWithPrefix(prefix)
+					it = db.NewIterator(prefix, nil)
 				} else {
-					it = db.NewIteratorWithStart(prefix)
+					it = db.NewIterator(nil, prefix)
 				}
 				defer it.Release()
 
@@ -303,7 +303,7 @@ func TestFlushableIterator(t *testing.T) {
 	flushable2.Put(veryFirstKey, []byte("first"))
 	flushable2.Put(veryLastKey, []byte("last"))
 
-	it := flushable1.NewIterator()
+	it := flushable1.NewIterator(nil, nil)
 	defer it.Release()
 
 	err := flushable2.Flush()

--- a/kvdb/flushable/flushable_test.go
+++ b/kvdb/flushable/flushable_test.go
@@ -3,6 +3,7 @@ package flushable
 import (
 	"bytes"
 	"fmt"
+	"github.com/syndtr/goleveldb/leveldb/opt"
 	"io/ioutil"
 	"math/big"
 	"math/rand"
@@ -378,10 +379,14 @@ func benchmarkFlushable(db *Flushable, goroutines, recs, flushPeriod int) {
 	wg.Wait()
 }
 
+func cache16mb(string) int {
+	return 16 * opt.MiB
+}
+
 func dbProducer(name string) kvdb.DbProducer {
 	dir, err := ioutil.TempDir("", name)
 	if err != nil {
 		panic(err)
 	}
-	return leveldb.NewProducer(dir)
+	return leveldb.NewProducer(dir, cache16mb)
 }

--- a/kvdb/interface.go
+++ b/kvdb/interface.go
@@ -52,18 +52,10 @@ type Batcher interface {
 
 // Iteratee wraps the NewIterator methods of a backing data store.
 type Iteratee interface {
-	// NewIterator creates a binary-alphabetical iterator over the entire keyspace
-	// contained within the key-value database.
-	NewIterator() Iterator
-
-	// NewIteratorWithStart creates a binary-alphabetical iterator over a subset of
-	// database content starting at a particular initial key (or after, if it does
-	// not exist).
-	NewIteratorWithStart(start []byte) Iterator
-
-	// NewIteratorWithPrefix creates a binary-alphabetical iterator over a subset
-	// of database content with a particular key prefix.
-	NewIteratorWithPrefix(prefix []byte) Iterator
+	// NewIterator creates a binary-alphabetical iterator over a subset
+	// of database content with a particular key prefix, starting at a particular
+	// initial key (or after, if it does not exist).
+	NewIterator(prefix []byte, start []byte) Iterator
 }
 
 // Store contains all the methods required to allow handling different

--- a/kvdb/leveldb/leveldb.go
+++ b/kvdb/leveldb/leveldb.go
@@ -142,23 +142,11 @@ func (db *Database) NewBatch() kvdb.Batch {
 	}
 }
 
-// NewIterator creates a binary-alphabetical iterator over the entire keyspace
-// contained within the leveldb database.
-func (db *Database) NewIterator() kvdb.Iterator {
-	return db.db.NewIterator(new(util.Range), nil)
-}
-
-// NewIteratorWithStart creates a binary-alphabetical iterator over a subset of
-// database content starting at a particular initial key (or after, if it does
-// not exist).
-func (db *Database) NewIteratorWithStart(start []byte) kvdb.Iterator {
-	return db.db.NewIterator(&util.Range{Start: start}, nil)
-}
-
-// NewIteratorWithPrefix creates a binary-alphabetical iterator over a subset
-// of database content with a particular key prefix.
-func (db *Database) NewIteratorWithPrefix(prefix []byte) kvdb.Iterator {
-	return db.db.NewIterator(util.BytesPrefix(prefix), nil)
+// NewIterator creates a binary-alphabetical iterator over a subset
+// of database content with a particular key prefix, starting at a particular
+// initial key (or after, if it does not exist).
+func (db *Database) NewIterator(prefix []byte, start []byte) kvdb.Iterator {
+	return db.db.NewIterator(bytesPrefixRange(prefix, start), nil)
 }
 
 // Stat returns a particular internal stat of the database.
@@ -247,4 +235,13 @@ func (r *replayer) Delete(key []byte) {
 		return
 	}
 	r.failure = r.writer.Delete(key)
+}
+
+// bytesPrefixRange returns key range that satisfy
+// - the given prefix, and
+// - the given seek position
+func bytesPrefixRange(prefix, start []byte) *util.Range {
+	r := util.BytesPrefix(prefix)
+	r.Start = append(r.Start, start...)
+	return r
 }

--- a/kvdb/leveldb/leveldb.go
+++ b/kvdb/leveldb/leveldb.go
@@ -16,9 +16,9 @@ import (
 )
 
 const (
-	// minCache is the minimum amount of memory in megabytes to allocate to leveldb
+	// minCache is the minimum amount of memory in bytes to allocate to leveldb
 	// read and write caching, split half and half.
-	minCache = 16
+	minCache = opt.KiB
 
 	// minHandles is the minimum number of files handles to allocate to the open
 	// database files.
@@ -52,8 +52,8 @@ func New(path string, cache int, handles int, close func() error, drop func()) (
 	// Open the db and recover any potential corruptions
 	db, err := leveldb.OpenFile(path, &opt.Options{
 		OpenFilesCacheCapacity: handles,
-		BlockCacheCapacity:     cache / 2 * opt.MiB,
-		WriteBuffer:            cache / 4 * opt.MiB, // Two of these are used internally
+		BlockCacheCapacity:     cache / 2,
+		WriteBuffer:            cache / 4, // Two of these are used internally
 		Filter:                 filter.NewBloomFilter(10),
 	})
 	if _, corrupted := err.(*errors.ErrCorrupted); corrupted {

--- a/kvdb/leveldb/producer.go
+++ b/kvdb/leveldb/producer.go
@@ -10,13 +10,15 @@ import (
 )
 
 type producer struct {
-	datadir string
+	datadir  string
+	getCache func(string) int
 }
 
 // NewProducer of level db.
-func NewProducer(datadir string) kvdb.DbProducer {
+func NewProducer(datadir string, getCache func(string) int) kvdb.DbProducer {
 	return &producer{
-		datadir: datadir,
+		datadir:  datadir,
+		getCache: getCache,
 	}
 }
 
@@ -67,7 +69,7 @@ func (p *producer) OpenDb(name string) kvdb.DropableStore {
 
 	}
 
-	db, err := New(path, 64, 0, onClose, onDrop)
+	db, err := New(path, p.getCache(name), 0, onClose, onDrop)
 	if err != nil {
 		panic(err)
 	}

--- a/kvdb/memorydb/memorydb_test.go
+++ b/kvdb/memorydb/memorydb_test.go
@@ -64,7 +64,7 @@ func TestMemoryDBIterator(t *testing.T) {
 			}
 		}
 		// Iterate over the database with the given configs and verify the results
-		it, idx := db.NewIteratorWithPrefix([]byte(tt.prefix)), 0
+		it, idx := db.NewIterator([]byte(tt.prefix), nil), 0
 		for it.Next() {
 			if !bytes.Equal(it.Key(), []byte(tt.order[idx])) {
 				t.Errorf("test %d: item %d: key mismatch: have %s, want %s", i, idx, string(it.Key()), tt.order[idx])

--- a/kvdb/nokeyiserr/wrapper.go
+++ b/kvdb/nokeyiserr/wrapper.go
@@ -2,6 +2,7 @@ package nokeyiserr
 
 import (
 	"errors"
+
 	"github.com/Fantom-foundation/lachesis-base/kvdb"
 )
 

--- a/kvdb/skiperrors/skiperrors.go
+++ b/kvdb/skiperrors/skiperrors.go
@@ -81,23 +81,11 @@ func (f *wrapper) NewBatch() kvdb.Batch {
 	return f.underlying.NewBatch()
 }
 
-// NewIterator creates a binary-alphabetical iterator over the entire keyspace
-// contained within the key-value database.
-func (f *wrapper) NewIterator() kvdb.Iterator {
-	return f.underlying.NewIterator()
-}
-
-// NewIteratorWithStart creates a binary-alphabetical iterator over a subset of
-// database content starting at a particular initial key (or after, if it does
-// not exist).
-func (f *wrapper) NewIteratorWithStart(start []byte) kvdb.Iterator {
-	return f.underlying.NewIteratorWithStart(start)
-}
-
-// NewIteratorWithPrefix creates a binary-alphabetical iterator over a subset
-// of database content with a particular key prefix.
-func (f *wrapper) NewIteratorWithPrefix(prefix []byte) kvdb.Iterator {
-	return f.underlying.NewIteratorWithPrefix(prefix)
+// NewIterator creates a binary-alphabetical iterator over a subset
+// of database content with a particular key prefix, starting at a particular
+// initial key (or after, if it does not exist).
+func (f *wrapper) NewIterator(prefix []byte, start []byte) kvdb.Iterator {
+	return f.underlying.NewIterator(prefix, start)
 }
 
 // Stat returns a particular internal stat of the database.

--- a/kvdb/table/reflect.go
+++ b/kvdb/table/reflect.go
@@ -2,8 +2,9 @@ package table
 
 import (
 	"bytes"
-	"github.com/Fantom-foundation/lachesis-base/kvdb"
 	"reflect"
+
+	"github.com/Fantom-foundation/lachesis-base/kvdb"
 )
 
 // MigrateTables sets target fields to database tables.

--- a/kvdb/table/table.go
+++ b/kvdb/table/table.go
@@ -1,8 +1,6 @@
 package table
 
 import (
-	"bytes"
-
 	"github.com/Fantom-foundation/lachesis-base/kvdb"
 )
 
@@ -41,8 +39,8 @@ func New(db kvdb.Store, prefix []byte) *Table {
 	return &Table{db, prefix}
 }
 
-func (t Table) NewTable(prefix []byte) *Table {
-	return &Table{t.db, prefix}
+func (t *Table) NewTable(prefix []byte) *Table {
+	return New(t, prefix)
 }
 
 func (t *Table) Close() error {
@@ -90,11 +88,7 @@ type iterator struct {
 }
 
 func (it *iterator) Next() bool {
-	next := it.it.Next()
-	for next && !bytes.HasPrefix(it.it.Key(), it.prefix) {
-		next = it.it.Next()
-	}
-	return next
+	return it.it.Next()
 }
 
 func (it *iterator) Error() error {
@@ -114,16 +108,8 @@ func (it *iterator) Release() {
 	*it = iterator{}
 }
 
-func (t *Table) NewIterator() kvdb.Iterator {
-	return &iterator{t.db.NewIteratorWithPrefix(t.prefix), t.prefix}
-}
-
-func (t *Table) NewIteratorWithStart(start []byte) kvdb.Iterator {
-	return &iterator{t.db.NewIteratorWithStart(prefixed(start, t.prefix)), t.prefix}
-}
-
-func (t *Table) NewIteratorWithPrefix(itPrefix []byte) kvdb.Iterator {
-	return &iterator{t.db.NewIteratorWithPrefix(prefixed(itPrefix, t.prefix)), t.prefix}
+func (t *Table) NewIterator(itPrefix []byte, start []byte) kvdb.Iterator {
+	return &iterator{t.db.NewIterator(prefixed(itPrefix, t.prefix), start), t.prefix}
 }
 
 /*

--- a/kvdb/table/table_test.go
+++ b/kvdb/table/table_test.go
@@ -69,9 +69,9 @@ func TestTable(t *testing.T) {
 			// tables
 			t1 := New(db, []byte("t1"))
 			tables := map[string]kvdb.Store{
-				"/t1":   t1,
-				"/t1/x": t1.NewTable([]byte("x")),
-				"/t2":   New(db, []byte("t2")),
+				"/t1":      t1,
+				"/x/t1/t2": New(db, []byte("x")).NewTable([]byte("t1t2")),
+				"/t2":      New(db, []byte("t2")),
 			}
 
 			// write
@@ -95,7 +95,7 @@ func TestTable(t *testing.T) {
 					got := 0
 					var prevKey []byte
 
-					it := t.NewIteratorWithPrefix([]byte(pref))
+					it := t.NewIterator([]byte(pref), nil)
 					defer it.Release()
 					for it.Next() {
 						if prevKey == nil {

--- a/vecfc/index.go
+++ b/vecfc/index.go
@@ -1,7 +1,7 @@
 package vecfc
 
 import (
-	"github.com/hashicorp/golang-lru"
+	lru "github.com/hashicorp/golang-lru"
 
 	"github.com/Fantom-foundation/lachesis-base/hash"
 	"github.com/Fantom-foundation/lachesis-base/inter/dag"


### PR DESCRIPTION
- refactor KV iterators to use interface `NewIterator(prefix, start []byte)`
- synced pool: refactor flush ID prefixes
- synced pool: configurable caches