### PR TITLE
Refactor gossip library

### DIFF
--- a/gossip/dagfetcher/config.go
+++ b/gossip/dagfetcher/config.go
@@ -3,33 +3,28 @@ package dagfetcher
 import "time"
 
 type Config struct {
-	ForgetTimeout time.Duration // RawTime before an announced event is forgotten
-	ArriveTimeout time.Duration // RawTime allowance before an announced event is explicitly requested
+	ForgetTimeout time.Duration // Time before an announced event is forgotten
+	ArriveTimeout time.Duration // Time allowance before an announced event is explicitly requested
 	GatherSlack   time.Duration // Interval used to collate almost-expired announces with fetches
-	FetchTimeout  time.Duration // Maximum allowed time to return an explicitly requested event
 	HashLimit     int           // Maximum number of unique events a peer may have announced
 
-	MaxEventsBatch int // Maximum number of events in an inject batch (batch is divided if exceeded)
-	MaxHashesBatch int // Maximum number of hashes in an announce batch (batch is divided if exceeded)
+	MaxBatch int // Maximum number of hashes in an announce batch (batch is divided if exceeded)
 
-	// MaxQueuedEventsBatches is the maximum number of inject batches to queue up before
-	// dropping incoming events.
-	MaxQueuedEventsBatches int
+	MaxParallelRequests int // Maximum number of parallel requests
+
 	// MaxQueuedHashesBatches is the maximum number of announce batches to queue up before
 	// dropping incoming hashes.
-	MaxQueuedHashesBatches int
+	MaxQueuedBatches int
 }
 
 func DefaultConfig() Config {
 	return Config{
-		ForgetTimeout:          1 * time.Minute,
-		ArriveTimeout:          1000 * time.Millisecond,
-		GatherSlack:            100 * time.Millisecond,
-		FetchTimeout:           10 * time.Second,
-		HashLimit:              10000,
-		MaxEventsBatch:         8,
-		MaxHashesBatch:         256,
-		MaxQueuedEventsBatches: 128,
-		MaxQueuedHashesBatches: 128,
+		ForgetTimeout:       1 * time.Minute,
+		ArriveTimeout:       1000 * time.Millisecond,
+		GatherSlack:         100 * time.Millisecond,
+		HashLimit:           20000,
+		MaxBatch:            512,
+		MaxQueuedBatches:    32,
+		MaxParallelRequests: 256,
 	}
 }

--- a/gossip/dagprocessor/config.go
+++ b/gossip/dagprocessor/config.go
@@ -1,0 +1,32 @@
+package dagprocessor
+
+import (
+	"time"
+
+	"github.com/syndtr/goleveldb/leveldb/opt"
+
+	"github.com/Fantom-foundation/lachesis-base/inter/dag"
+)
+
+type Config struct {
+	EventsBufferLimit dag.Metric
+
+	EventsSemaphoreTimeout time.Duration
+
+	MaxUnorderedInsertions int
+}
+
+func (c Config) MaxTasks() int {
+	return c.MaxUnorderedInsertions*2 + 1
+}
+
+func DefaultConfig() Config {
+	return Config{
+		EventsBufferLimit: dag.Metric{
+			// Shouldn't be too big because complexity is O(n) for each insertion in the EventsBuffer
+			Num:  500,
+			Size: 10 * opt.MiB,
+		},
+		EventsSemaphoreTimeout: 10 * time.Second,
+	}
+}

--- a/gossip/dagprocessor/processor.go
+++ b/gossip/dagprocessor/processor.go
@@ -1,0 +1,196 @@
+package dagprocessor
+
+import (
+	"errors"
+	"runtime"
+	"sync"
+	"time"
+
+	"github.com/Fantom-foundation/lachesis-base/gossip/dagfetcher"
+	"github.com/Fantom-foundation/lachesis-base/gossip/dagordering"
+	"github.com/Fantom-foundation/lachesis-base/hash"
+	"github.com/Fantom-foundation/lachesis-base/inter/dag"
+	"github.com/Fantom-foundation/lachesis-base/utils/datasemaphore"
+	"github.com/Fantom-foundation/lachesis-base/utils/workers"
+)
+
+var (
+	ErrBusy = errors.New("failed to acquire events semaphore")
+)
+
+// Processor is responsible for processing incoming events
+type Processor struct {
+	cfg Config
+
+	quit chan struct{}
+	wg   sync.WaitGroup
+
+	callback Callback
+
+	orderedInserter    *workers.Workers
+	unorderedInserters *workers.Workers
+
+	buffer *dagordering.EventsBuffer
+
+	eventsSemaphore *datasemaphore.DataSemaphore
+}
+
+type EventCallback struct {
+	Process         func(e dag.Event) error
+	Released        func(e dag.Event, peer string, err error)
+	Get             func(hash.Event) dag.Event
+	Exists          func(hash.Event) bool
+	OnlyInterested  func(ids hash.Events) hash.Events
+	CheckParents    func(e dag.Event, parents dag.Events) error
+	CheckParentless func(inEvents dag.Events, checked func(ee dag.Events, errs []error))
+}
+
+type Callback struct {
+	Event EventCallback
+	// PeerMisbehaviour is a callback type for dropping a peer detected as malicious.
+	PeerMisbehaviour func(peer string, err error) bool
+
+	NotifyAnnounces func(peer string, ids hash.Events, time time.Time, fetchEvents dagfetcher.EventsRequesterFn) error
+}
+
+// New creates an event processor
+func New(eventsSemaphore *datasemaphore.DataSemaphore, cfg Config, callback Callback) *Processor {
+	if cfg.MaxUnorderedInsertions == 0 {
+		cfg.MaxUnorderedInsertions = runtime.NumCPU()
+	}
+
+	f := &Processor{
+		cfg:             cfg,
+		quit:            make(chan struct{}),
+		eventsSemaphore: eventsSemaphore,
+	}
+	released := callback.Event.Released
+	callback.Event.Released = func(e dag.Event, peer string, err error) {
+		f.eventsSemaphore.Release(dag.Metric{1, uint64(e.Size())})
+		if released != nil {
+			released(e, peer, err)
+		}
+	}
+	f.callback = callback
+	f.buffer = dagordering.New(cfg.EventsBufferLimit, dagordering.Callback{
+		Process:  callback.Event.Process,
+		Released: callback.Event.Released,
+		Get:      callback.Event.Get,
+		Exists:   callback.Event.Exists,
+		Check:    callback.Event.CheckParents,
+	})
+	f.orderedInserter = workers.New(&f.wg, f.quit, cfg.MaxTasks())
+	f.unorderedInserters = workers.New(&f.wg, f.quit, cfg.MaxTasks())
+	return f
+}
+
+// Start boots up the events processor.
+func (f *Processor) Start() {
+	f.orderedInserter.Start(1)
+	f.unorderedInserters.Start(f.cfg.MaxUnorderedInsertions)
+}
+
+// Stop interrupts the processor, canceling all the pending operations.
+// Stop waits until all the internal goroutines have finished.
+func (f *Processor) Stop() {
+	close(f.quit)
+	f.eventsSemaphore.Terminate()
+	f.Clear()
+	f.wg.Wait()
+	f.buffer.Clear()
+}
+
+// Overloaded returns true if too much events are being processed or requested
+func (f *Processor) Overloaded() bool {
+	return f.unorderedInserters.TasksCount() > f.cfg.MaxTasks()*3/4 ||
+		f.orderedInserter.TasksCount() > f.cfg.MaxTasks()*3/4
+}
+
+type eventErrPair struct {
+	event dag.Event
+	err   error
+}
+
+func (f *Processor) Enqueue(peer string, events dag.Events, ordered bool, time time.Time, fetchEvents dagfetcher.EventsRequesterFn) error {
+	if !f.eventsSemaphore.Acquire(events.Metric(), f.cfg.EventsSemaphoreTimeout) {
+		return ErrBusy
+	}
+
+	inserter := f.unorderedInserters
+	if ordered {
+		inserter = f.orderedInserter
+	}
+
+	return inserter.Enqueue(func() {
+		checkedC := make(chan eventErrPair, len(events))
+		f.callback.Event.CheckParentless(events, func(checked dag.Events, errs []error) {
+			for i, e := range checked {
+				checkedC <- eventErrPair{e, errs[i]}
+			}
+		})
+
+		var orderedResults []eventErrPair
+		var eventPos map[hash.Event]int
+		if ordered {
+			orderedResults = make([]eventErrPair, len(events))
+			eventPos = make(map[hash.Event]int, len(events))
+			for i, e := range events {
+				eventPos[e.ID()] = i
+			}
+		}
+		var processed int
+		var toRequest hash.Events
+		for processed < len(events) {
+			select {
+			case res := <-checkedC:
+				if ordered {
+					orderedResults[eventPos[res.event.ID()]] = res
+
+					for i := processed; processed < len(orderedResults) && orderedResults[i].event != nil; i++ {
+						toRequest = append(toRequest, f.process(peer, orderedResults[i])...)
+						processed++
+					}
+				} else {
+					toRequest = append(toRequest, f.process(peer, res)...)
+					processed++
+				}
+
+			case <-f.quit:
+				return
+			}
+		}
+
+		// request unknown event parents
+		if len(toRequest) != 0 {
+			_ = f.callback.NotifyAnnounces(peer, toRequest, time, fetchEvents)
+		}
+	})
+}
+
+func (f *Processor) process(peer string, res eventErrPair) (toRequest hash.Events) {
+	if res.err != nil {
+		f.callback.PeerMisbehaviour(peer, res.err)
+		f.callback.Event.Released(res.event, peer, res.err)
+		return hash.Events{}
+	}
+	complete := f.buffer.PushEvent(res.event, peer)
+	if !complete {
+		return res.event.Parents()
+	}
+	return hash.Events{}
+}
+
+func (f *Processor) IsBuffered(id hash.Event) bool {
+	return f.buffer.IsBuffered(id)
+}
+
+// Clear
+func (f *Processor) Clear() {
+	f.buffer.Clear()
+	f.unorderedInserters.Drain()
+	f.orderedInserter.Drain()
+}
+
+func (f *Processor) TotalBuffered() dag.Metric {
+	return f.buffer.Total()
+}

--- a/gossip/dagstream/streamleecher/peerleecher/session.go
+++ b/gossip/dagstream/streamleecher/peerleecher/session.go
@@ -60,9 +60,9 @@ type PeerLeecher struct {
 func New(wg *sync.WaitGroup, cfg EpochDownloaderConfig, callback EpochDownloaderCallbacks) *PeerLeecher {
 	quit := make(chan struct{})
 	return &PeerLeecher{
-		processingChunks:    make([]receivedChunk, 0, cfg.ParallelChunksDownload+1),
-		parallelTasks:       workers.New(wg, quit, cfg.ParallelChunksDownload+1),
-		notifyReceivedChunk: make(chan *receivedChunk, cfg.ParallelChunksDownload+1),
+		processingChunks:    make([]receivedChunk, 0, cfg.ParallelChunksDownload*2),
+		parallelTasks:       workers.New(wg, quit, cfg.ParallelChunksDownload*2),
+		notifyReceivedChunk: make(chan *receivedChunk, cfg.ParallelChunksDownload*2),
 		quit:                quit,
 		cfg:                 cfg,
 		callback:            callback,
@@ -93,6 +93,7 @@ func (d *PeerLeecher) Terminate() {
 	defer d.quitMu.Unlock()
 	if !d.done {
 		close(d.quit)
+		d.parallelTasks.Drain()
 		d.done = true
 	}
 }

--- a/gossip/dagstream/streamseeder/config.go
+++ b/gossip/dagstream/streamseeder/config.go
@@ -1,11 +1,15 @@
 package streamseeder
 
 type Config struct {
-	SenderThreads int
+	SenderThreads           int
+	MaxMaxSenderTasks       int
+	MaxPendingResponsesSize int32
 }
 
 func DefaultConfig() Config {
 	return Config{
-		SenderThreads: 1,
+		SenderThreads:           8,
+		MaxPendingResponsesSize: 64 * 1024 * 1024,
+		MaxMaxSenderTasks:       128,
 	}
 }

--- a/inter/dag/events.go
+++ b/inter/dag/events.go
@@ -3,6 +3,7 @@ package dag
 import (
 	"strings"
 
+	"github.com/Fantom-foundation/lachesis-base/hash"
 	"github.com/Fantom-foundation/lachesis-base/inter/idx"
 )
 
@@ -24,4 +25,12 @@ func (ee Events) Metric() (metric Metric) {
 		metric.Size += uint64(e.Size())
 	}
 	return metric
+}
+
+func (ee Events) IDs() hash.Events {
+	ids := make(hash.Events, len(ee))
+	for i, e := range ee {
+		ids[i] = e.ID()
+	}
+	return ids
 }

--- a/utils/workers/workers.go
+++ b/utils/workers/workers.go
@@ -42,6 +42,21 @@ func (w *Workers) Enqueue(fn func()) error {
 	}
 }
 
+func (w *Workers) Drain() {
+	for {
+		select {
+		case <-w.tasks:
+			continue
+		default:
+			return
+		}
+	}
+}
+
+func (w *Workers) TasksCount() int {
+	return len(w.tasks)
+}
+
 func worker(tasksC <-chan func(), quit <-chan struct{}) {
 	for {
 		select {


### PR DESCRIPTION
- dagfetcher: doesn't perform event processing
- dagprocessor: performs event processing. If explicitly specified, pushes events into the buffer strictly in order in which they were received
- streamseeder: limit RAM usage, send session responses in order of requests

Due to the ordered processing in dagprocessor and ordered responses in streamseeder, events buffer is not utilized during events stream download, because all the stream events are sent and pushed in buffer in an order in which they may be processed