### PR TITLE
SyncedPool.GetUnderlying()

### DIFF
--- a/kvdb/flushable/flushable.go
+++ b/kvdb/flushable/flushable.go
@@ -232,7 +232,7 @@ func (w *Flushable) Compact(start []byte, limit []byte) error {
  * Iterator
  */
 
-type iterator struct {
+type flushableIterator struct {
 	lock *sync.Mutex
 
 	tree *rbt.Tree
@@ -287,7 +287,7 @@ func castToPair(node *rbt.Node) (key, val []byte) {
 }
 
 // init should be called once under lock
-func (it *iterator) init() {
+func (it *flushableIterator) init() {
 	it.parentOk = it.parentIt.Next()
 	if it.start != nil {
 		it.treeNode, it.treeOk = it.tree.Ceiling(string(it.start)) // not strict >=
@@ -297,8 +297,9 @@ func (it *iterator) init() {
 	}
 }
 
-// Next scans key-value pair by key in lexicographic order. Looks in cache first, then - in DB.
-func (it *iterator) Next() bool {
+// Next scans key-value pair by key in lexicographic order. Looks in cache first,
+// then - in DB.
+func (it *flushableIterator) Next() bool {
 	it.lock.Lock()
 	defer it.lock.Unlock()
 
@@ -365,36 +366,38 @@ func (it *iterator) Next() bool {
 
 // Error returns any accumulated error. Exhausting all the key/value pairs
 // is not considered to be an error. A memory iterator cannot encounter errors.
-func (it *iterator) Error() error {
+func (it *flushableIterator) Error() error {
 	return it.parentIt.Error()
 }
 
 // Key returns the key of the current key/value pair, or nil if done. The caller
 // should not modify the contents of the returned slice, and its contents may
 // change on the next call to Next.
-func (it *iterator) Key() []byte {
+func (it *flushableIterator) Key() []byte {
 	return it.key
 }
 
 // Value returns the value of the current key/value pair, or nil if done. The
 // caller should not modify the contents of the returned slice, and its contents
 // may change on the next call to Next.
-func (it *iterator) Value() []byte {
+func (it *flushableIterator) Value() []byte {
 	return it.val
 }
 
 // Release releases associated resources. Release should always succeed and can
 // be called multiple times without causing error.
-func (it *iterator) Release() {
+func (it *flushableIterator) Release() {
 	it.parentIt.Release()
-	*it = iterator{}
+	*it = flushableIterator{
+		parentIt: it.parentIt,
+	}
 }
 
 // NewIterator creates a binary-alphabetical iterator over a subset
 // of database content with a particular key prefix, starting at a particular
 // initial key (or after, if it does not exist).
 func (w *Flushable) NewIterator(prefix []byte, start []byte) kvdb.Iterator {
-	it := &iterator{
+	it := &flushableIterator{
 		lock:     w.lock,
 		tree:     w.modified,
 		start:    append(common.CopyBytes(prefix), start...),

--- a/kvdb/flushable/flushable.go
+++ b/kvdb/flushable/flushable.go
@@ -95,7 +95,7 @@ func (w *Flushable) Has(key []byte) (bool, error) {
 	return w.underlying.Has(key)
 }
 
-// get returns key-value pair by key. Looks in cache first, then - in DB.
+// Get returns key-value pair by key. Looks in cache first, then - in DB.
 func (w *Flushable) Get(key []byte) ([]byte, error) {
 	w.lock.Lock()
 	defer w.lock.Unlock()

--- a/kvdb/flushable/readonly.go
+++ b/kvdb/flushable/readonly.go
@@ -39,16 +39,6 @@ func (ro *Readonly) Get(key []byte) ([]byte, error) {
 	return ro.underlying.Get(key)
 }
 
-// NewIterator creates a binary-alphabetical iterator over a subset
-// of database content with a particular key prefix, starting at a particular
-// initial key (or after, if it does not exist).
-func (ro *Readonly) NewIterator(prefix []byte, start []byte) kvdb.Iterator {
-	ro.mu.RLock()
-	defer ro.mu.RUnlock()
-	// NOTE: iterator's methods are not locked with ro.mu
-	return ro.underlying.NewIterator(prefix, start)
-}
-
 // Stat returns a particular internal stat of the database.
 func (ro *Readonly) Stat(property string) (string, error) {
 	ro.mu.RLock()
@@ -63,4 +53,61 @@ func (ro *Readonly) Compact(start []byte, limit []byte) error {
 	defer ro.mu.RUnlock()
 
 	return ro.underlying.Compact(start, limit)
+}
+
+// NewIterator creates a binary-alphabetical iterator over a subset
+// of database content with a particular key prefix, starting at a particular
+// initial key (or after, if it does not exist).
+func (ro *Readonly) NewIterator(prefix []byte, start []byte) kvdb.Iterator {
+	ro.mu.RLock()
+	defer ro.mu.RUnlock()
+
+	return &readonlyIterator{
+		mu:       ro.mu,
+		parentIt: ro.underlying.NewIterator(prefix, start),
+	}
+}
+
+/*
+ * Iterator
+ */
+
+type readonlyIterator struct {
+	mu       *sync.RWMutex
+	parentIt kvdb.Iterator
+}
+
+// Next scans key-value pair by key in lexicographic order. Looks in cache first,
+// then - in DB.
+func (it *readonlyIterator) Next() bool {
+	it.mu.RLock()
+	defer it.mu.RUnlock()
+
+	return it.parentIt.Next()
+}
+
+// Error returns any accumulated error. Exhausting all the key/value pairs
+// is not considered to be an error. A memory iterator cannot encounter errors.
+func (it *readonlyIterator) Error() error {
+	return it.parentIt.Error()
+}
+
+// Key returns the key of the current key/value pair, or nil if done. The caller
+// should not modify the contents of the returned slice, and its contents may
+// change on the next call to Next.
+func (it *readonlyIterator) Key() []byte {
+	return it.parentIt.Key()
+}
+
+// Value returns the value of the current key/value pair, or nil if done. The
+// caller should not modify the contents of the returned slice, and its contents
+// may change on the next call to Next.
+func (it *readonlyIterator) Value() []byte {
+	return it.parentIt.Value()
+}
+
+// Release releases associated resources. Release should always succeed and can
+// be called multiple times without causing error.
+func (it *readonlyIterator) Release() {
+	it.parentIt.Release()
 }

--- a/kvdb/flushable/readonly.go
+++ b/kvdb/flushable/readonly.go
@@ -1,18 +1,22 @@
 package flushable
 
 import (
+	"sync"
+
 	"github.com/Fantom-foundation/lachesis-base/kvdb"
 )
 
 // Readonly kvdb.Store wrapper around any Database.
 type Readonly struct {
+	mu         *sync.RWMutex
 	underlying kvdb.Store
 }
 
 // Wrap underlying db.
 // Allows the readings only.
-func WrapWithReadonly(parent kvdb.Store) *Readonly {
+func WrapWithReadonly(parent kvdb.Store, mu *sync.RWMutex) *Readonly {
 	ro := &Readonly{
+		mu:         mu,
 		underlying: parent,
 	}
 
@@ -21,18 +25,49 @@ func WrapWithReadonly(parent kvdb.Store) *Readonly {
 
 // Has checks if key is in the exists.
 func (ro *Readonly) Has(key []byte) (bool, error) {
+	ro.mu.RLock()
+	defer ro.mu.RUnlock()
+
 	return ro.underlying.Has(key)
 }
 
 // Get returns key-value pair by key.
 func (ro *Readonly) Get(key []byte) ([]byte, error) {
+	ro.mu.RLock()
+	defer ro.mu.RUnlock()
+
 	return ro.underlying.Get(key)
+}
+
+// NewIterator creates a binary-alphabetical iterator over a subset
+// of database content with a particular key prefix, starting at a particular
+// initial key (or after, if it does not exist).
+func (ro *Readonly) NewIterator(prefix []byte, start []byte) kvdb.Iterator {
+	ro.mu.RLock()
+	defer ro.mu.RUnlock()
+	// NOTE: iterator's methods are not locked with ro.mu
+	return ro.underlying.NewIterator(prefix, start)
+}
+
+// Stat returns a particular internal stat of the database.
+func (ro *Readonly) Stat(property string) (string, error) {
+	ro.mu.RLock()
+	defer ro.mu.RUnlock()
+
+	return ro.underlying.Stat(property)
+}
+
+// Compact flattens the underlying data store for the given key range.
+func (ro *Readonly) Compact(start []byte, limit []byte) error {
+	ro.mu.RLock()
+	defer ro.mu.RUnlock()
+
+	return ro.underlying.Compact(start, limit)
 }
 
 // Put puts key-value pair into the cache.
 func (ro *Readonly) Put(key []byte, value []byte) error {
 	panic("is not allowed, readonly")
-
 	return ro.underlying.Put(key, value)
 }
 
@@ -46,23 +81,6 @@ func (ro *Readonly) NewBatch() kvdb.Batch {
 func (ro *Readonly) Delete(key []byte) error {
 	panic("is not allowed, readonly")
 	return ro.underlying.Delete(key)
-}
-
-// NewIterator creates a binary-alphabetical iterator over a subset
-// of database content with a particular key prefix, starting at a particular
-// initial key (or after, if it does not exist).
-func (ro *Readonly) NewIterator(prefix []byte, start []byte) kvdb.Iterator {
-	return ro.underlying.NewIterator(prefix, start)
-}
-
-// Stat returns a particular internal stat of the database.
-func (ro *Readonly) Stat(property string) (string, error) {
-	return ro.underlying.Stat(property)
-}
-
-// Compact flattens the underlying data store for the given key range.
-func (ro *Readonly) Compact(start []byte, limit []byte) error {
-	return ro.underlying.Compact(start, limit)
 }
 
 // Close leaves underlying database.

--- a/kvdb/flushable/readonly.go
+++ b/kvdb/flushable/readonly.go
@@ -1,0 +1,72 @@
+package flushable
+
+import (
+	"github.com/Fantom-foundation/lachesis-base/kvdb"
+)
+
+// Readonly kvdb.Store wrapper around any Database.
+type Readonly struct {
+	underlying kvdb.Store
+}
+
+// Wrap underlying db.
+// Allows the readings only.
+func WrapWithReadonly(parent kvdb.Store) *Readonly {
+	ro := &Readonly{
+		underlying: parent,
+	}
+
+	return ro
+}
+
+// Has checks if key is in the exists.
+func (ro *Readonly) Has(key []byte) (bool, error) {
+	return ro.underlying.Has(key)
+}
+
+// Get returns key-value pair by key.
+func (ro *Readonly) Get(key []byte) ([]byte, error) {
+	return ro.underlying.Get(key)
+}
+
+// Put puts key-value pair into the cache.
+func (ro *Readonly) Put(key []byte, value []byte) error {
+	panic("is not allowed, readonly")
+
+	return ro.underlying.Put(key, value)
+}
+
+// NewBatch creates new batch.
+func (ro *Readonly) NewBatch() kvdb.Batch {
+	panic("is not allowed, readonly")
+	return ro.underlying.NewBatch()
+}
+
+// Delete removes key-value pair by key.
+func (ro *Readonly) Delete(key []byte) error {
+	panic("is not allowed, readonly")
+	return ro.underlying.Delete(key)
+}
+
+// NewIterator creates a binary-alphabetical iterator over a subset
+// of database content with a particular key prefix, starting at a particular
+// initial key (or after, if it does not exist).
+func (ro *Readonly) NewIterator(prefix []byte, start []byte) kvdb.Iterator {
+	return ro.underlying.NewIterator(prefix, start)
+}
+
+// Stat returns a particular internal stat of the database.
+func (ro *Readonly) Stat(property string) (string, error) {
+	return ro.underlying.Stat(property)
+}
+
+// Compact flattens the underlying data store for the given key range.
+func (ro *Readonly) Compact(start []byte, limit []byte) error {
+	return ro.underlying.Compact(start, limit)
+}
+
+// Close leaves underlying database.
+func (ro *Readonly) Close() error {
+	panic("is not allowed, readonly")
+	return ro.underlying.Close()
+}

--- a/kvdb/flushable/readonly.go
+++ b/kvdb/flushable/readonly.go
@@ -6,7 +6,7 @@ import (
 	"github.com/Fantom-foundation/lachesis-base/kvdb"
 )
 
-// Readonly kvdb.Store wrapper around any Database.
+// Readonly kvdb.ReadonlyStore wrapper around any Database.
 type Readonly struct {
 	mu         *sync.RWMutex
 	underlying kvdb.Store
@@ -63,28 +63,4 @@ func (ro *Readonly) Compact(start []byte, limit []byte) error {
 	defer ro.mu.RUnlock()
 
 	return ro.underlying.Compact(start, limit)
-}
-
-// Put puts key-value pair into the cache.
-func (ro *Readonly) Put(key []byte, value []byte) error {
-	panic("is not allowed, readonly")
-	return ro.underlying.Put(key, value)
-}
-
-// NewBatch creates new batch.
-func (ro *Readonly) NewBatch() kvdb.Batch {
-	panic("is not allowed, readonly")
-	return ro.underlying.NewBatch()
-}
-
-// Delete removes key-value pair by key.
-func (ro *Readonly) Delete(key []byte) error {
-	panic("is not allowed, readonly")
-	return ro.underlying.Delete(key)
-}
-
-// Close leaves underlying database.
-func (ro *Readonly) Close() error {
-	panic("is not allowed, readonly")
-	return ro.underlying.Close()
 }

--- a/kvdb/flushable/synced_pool.go
+++ b/kvdb/flushable/synced_pool.go
@@ -18,7 +18,7 @@ const (
 	CleanPrefix = 0x00
 )
 
-type wrapperSet struct {
+type wrappers struct {
 	*LazyFlushable
 	*Readonly
 }
@@ -26,7 +26,7 @@ type wrapperSet struct {
 type SyncedPool struct {
 	producer kvdb.DBProducer
 
-	wrappers    map[string]wrapperSet
+	wrappers    map[string]wrappers
 	queuedDrops map[string]struct{}
 
 	flushIDKey []byte
@@ -42,7 +42,7 @@ func NewSyncedPool(producer kvdb.DBProducer, flushIDKey []byte) *SyncedPool {
 
 	p := &SyncedPool{
 		producer:    producer,
-		wrappers:    make(map[string]wrapperSet),
+		wrappers:    make(map[string]wrappers),
 		queuedDrops: make(map[string]struct{}),
 		flushIDKey:  flushIDKey,
 	}

--- a/kvdb/flushable/synced_pool.go
+++ b/kvdb/flushable/synced_pool.go
@@ -21,7 +21,7 @@ const (
 
 type wrappers struct {
 	*LazyFlushable
-	*synced.ReadonlyStore
+	kvdb.ReadonlyStore
 }
 
 type SyncedPool struct {

--- a/kvdb/flushable/synced_pool.go
+++ b/kvdb/flushable/synced_pool.go
@@ -90,7 +90,7 @@ func (p *SyncedPool) OpenDB(name string) (kvdb.DropableStore, error) {
 	return p.getDb(name), nil
 }
 
-func (p *SyncedPool) GetReadonly(name string) (kvdb.Store, error) {
+func (p *SyncedPool) GetUnderlying(name string) (kvdb.ReadonlyStore, error) {
 	p.Lock()
 	defer p.Unlock()
 

--- a/kvdb/flushable/synced_pool_test.go
+++ b/kvdb/flushable/synced_pool_test.go
@@ -5,14 +5,74 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/Fantom-foundation/lachesis-base/common/bigendian"
+	"github.com/Fantom-foundation/lachesis-base/kvdb"
 	"github.com/Fantom-foundation/lachesis-base/kvdb/memorydb"
+	"github.com/Fantom-foundation/lachesis-base/kvdb/table"
 )
 
-func TestSyncedPool(t *testing.T) {
+func TestSyncedPoolUnderlying(t *testing.T) {
 	require := require.New(t)
+	const (
+		N       = 1000
+		dbname1 = "db1"
+		dbname2 = "db2"
+		tbname  = "table"
+	)
 
 	dbs := memorydb.NewProducer("")
-	pool := NewSyncedPool(dbs)
+	pool := NewSyncedPool(dbs, []byte("flushID"))
 
-	require.NotNil(pool)
+	db1, err := pool.GetUnderlying(dbname1)
+	require.NoError(err)
+	r1 := table.NewReadonly(db1, []byte(tbname))
+
+	fdb1, err := pool.OpenDB(dbname1)
+	require.NoError(err)
+	w1 := table.New(fdb1, []byte(tbname))
+
+	fdb2, err := pool.OpenDB(dbname2)
+	require.NoError(err)
+	w2 := table.New(fdb2, []byte(tbname))
+
+	db2, err := pool.GetUnderlying(dbname2)
+	require.NoError(err)
+	r2 := table.NewReadonly(db2, []byte(tbname))
+
+	pushData := func(n uint32, w kvdb.Store) {
+		const size uint32 = 10
+		for i := size; i > 0; i-- {
+			key := bigendian.Uint32ToBytes(i + size*n)
+			w.Put(key, key)
+		}
+	}
+
+	checkConsistency := func() {
+		it := r1.NewIterator(nil, nil)
+		defer it.Release()
+		var prev uint32 = 0
+		for it.Next() {
+			key1 := it.Key()
+			i := bigendian.BytesToUint32(key1)
+			require.Equal(prev+1, i)
+			prev = i
+
+			key2, err := r2.Get(key1)
+			require.NoError(err)
+			require.Equal(key1, key2)
+		}
+	}
+
+	pushData(0, w1)
+	checkConsistency()
+
+	pushData(0, w2)
+	pool.Flush(nil)
+	checkConsistency()
+
+	pushData(1, w1)
+	pushData(1, w2)
+	checkConsistency()
+	pool.Flush(nil)
+	checkConsistency()
 }

--- a/kvdb/flushable/synced_pool_test.go
+++ b/kvdb/flushable/synced_pool_test.go
@@ -1,0 +1,18 @@
+package flushable
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/Fantom-foundation/lachesis-base/kvdb/memorydb"
+)
+
+func TestSyncedPool(t *testing.T) {
+	require := require.New(t)
+
+	dbs := memorydb.NewProducer("")
+	pool := NewSyncedPool(dbs)
+
+	require.NotNil(pool)
+}

--- a/kvdb/interface.go
+++ b/kvdb/interface.go
@@ -74,6 +74,7 @@ type Store interface {
 type ReadonlyStore interface {
 	Reader
 	Iteratee
+	ethdb.Stater
 }
 
 // Droper is able to delete the DB.

--- a/kvdb/interface.go
+++ b/kvdb/interface.go
@@ -70,6 +70,12 @@ type Store interface {
 	io.Closer
 }
 
+// ReadonlyStore contains only reading methods of Store.
+type ReadonlyStore interface {
+	Reader
+	Iteratee
+}
+
 // Droper is able to delete the DB.
 type Droper interface {
 	Drop()

--- a/kvdb/synced/readonly.go
+++ b/kvdb/synced/readonly.go
@@ -6,15 +6,15 @@ import (
 	"github.com/Fantom-foundation/lachesis-base/kvdb"
 )
 
-// ReadonlyStore wrapper around any Database.
-type ReadonlyStore struct {
+// readonlyStore wrapper around any kvdb.ReadonlyStore.
+type readonlyStore struct {
 	mu         *sync.RWMutex
 	underlying kvdb.ReadonlyStore
 }
 
 // WrapReadonlyStore underlying db to make its methods synced with mu.
-func WrapReadonlyStore(parent kvdb.ReadonlyStore, mu *sync.RWMutex) *ReadonlyStore {
-	ro := &ReadonlyStore{
+func WrapReadonlyStore(parent kvdb.ReadonlyStore, mu *sync.RWMutex) kvdb.ReadonlyStore {
+	ro := &readonlyStore{
 		mu:         mu,
 		underlying: parent,
 	}
@@ -23,7 +23,7 @@ func WrapReadonlyStore(parent kvdb.ReadonlyStore, mu *sync.RWMutex) *ReadonlySto
 }
 
 // Has checks if key is in the exists.
-func (ro *ReadonlyStore) Has(key []byte) (bool, error) {
+func (ro *readonlyStore) Has(key []byte) (bool, error) {
 	ro.mu.RLock()
 	defer ro.mu.RUnlock()
 
@@ -31,7 +31,7 @@ func (ro *ReadonlyStore) Has(key []byte) (bool, error) {
 }
 
 // Get returns key-value pair by key.
-func (ro *ReadonlyStore) Get(key []byte) ([]byte, error) {
+func (ro *readonlyStore) Get(key []byte) ([]byte, error) {
 	ro.mu.RLock()
 	defer ro.mu.RUnlock()
 
@@ -39,7 +39,7 @@ func (ro *ReadonlyStore) Get(key []byte) ([]byte, error) {
 }
 
 // Stat returns a particular internal stat of the database.
-func (ro *ReadonlyStore) Stat(property string) (string, error) {
+func (ro *readonlyStore) Stat(property string) (string, error) {
 	ro.mu.RLock()
 	defer ro.mu.RUnlock()
 
@@ -49,7 +49,7 @@ func (ro *ReadonlyStore) Stat(property string) (string, error) {
 // NewIterator creates a binary-alphabetical iterator over a subset
 // of database content with a particular key prefix, starting at a particular
 // initial key (or after, if it does not exist).
-func (ro *ReadonlyStore) NewIterator(prefix []byte, start []byte) kvdb.Iterator {
+func (ro *readonlyStore) NewIterator(prefix []byte, start []byte) kvdb.Iterator {
 	ro.mu.RLock()
 	defer ro.mu.RUnlock()
 

--- a/kvdb/synced/store.go
+++ b/kvdb/synced/store.go
@@ -1,0 +1,116 @@
+package synced
+
+import (
+	"sync"
+
+	"github.com/Fantom-foundation/lachesis-base/kvdb"
+)
+
+// store wrapper around any kvdb.Store.
+type store struct {
+	readonlyStore
+	underlying kvdb.Store
+}
+
+// WrapStore underlying db to make its methods synced with mu.
+func WrapStore(parent kvdb.Store, mu *sync.RWMutex) kvdb.Store {
+	s := &store{
+		readonlyStore: readonlyStore{
+			mu:         mu,
+			underlying: parent,
+		},
+		underlying: parent,
+	}
+
+	return s
+}
+
+// Put puts key-value pair into the cache.
+func (s *store) Put(key []byte, value []byte) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return s.underlying.Put(key, value)
+}
+
+// Delete removes key-value pair by key.
+func (s *store) Delete(key []byte) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return s.underlying.Delete(key)
+}
+
+// Compact flattens the underlying data store for the given key range.
+func (s *store) Compact(start []byte, limit []byte) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return s.underlying.Compact(start, limit)
+}
+
+// Close leaves underlying database.
+func (s *store) Close() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return s.underlying.Close()
+}
+
+// NewBatch creates new batch.
+func (s *store) NewBatch() kvdb.Batch {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return &syncedBatch{
+		mu:         s.mu,
+		underlying: s.underlying.NewBatch(),
+	}
+
+}
+
+/*
+ * Batch
+ */
+
+// syncedBatch wraps a batch.
+type syncedBatch struct {
+	mu         *sync.RWMutex
+	underlying kvdb.Batch
+}
+
+// Put adds "add key-value pair" operation into batch.
+func (b *syncedBatch) Put(key, value []byte) error {
+	return b.underlying.Put(key, value)
+}
+
+// Delete adds "remove key" operation into batch.
+func (b *syncedBatch) Delete(key []byte) error {
+	return b.underlying.Delete(key)
+}
+
+// Write writes batch into db. Not atomic.
+func (b *syncedBatch) Write() error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	return b.underlying.Write()
+}
+
+// ValueSize returns key-values sizes sum.
+func (b *syncedBatch) ValueSize() int {
+	return b.underlying.ValueSize()
+}
+
+// Reset cleans whole batch.
+func (b *syncedBatch) Reset() {
+	b.underlying.Reset()
+}
+
+// Replay replays the batch contents.
+func (b *syncedBatch) Replay(w kvdb.Writer) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	return b.underlying.Replay(w)
+}

--- a/kvdb/table/readonly.go
+++ b/kvdb/table/readonly.go
@@ -4,37 +4,65 @@ import (
 	"github.com/Fantom-foundation/lachesis-base/kvdb"
 )
 
-// readonly kvdb.Store panics on any data mutation.
-type readonly struct {
-	kvdb.ReadonlyStore
+// Readonly table wraper of the underling DB, so all the table's data is stored with a prefix in underling DB.
+type Readonly struct {
+	prefix     []byte
+	underlying kvdb.ReadonlyStore
 }
 
-// Put puts key-value pair into the cache.
-func (ro *readonly) Put(key []byte, value []byte) error {
-	panic("readonly!")
-	return nil
+func NewReadonly(db kvdb.ReadonlyStore, prefix []byte) *Readonly {
+	return &Readonly{
+		underlying: db,
+		prefix:     prefix,
+	}
 }
 
-// Delete removes key-value pair by key.
-func (ro *readonly) Delete(key []byte) error {
-	panic("readonly!")
-	return nil
+func (t *Readonly) NewReadonlyTable(prefix []byte) *Readonly {
+	return NewReadonly(t, prefix)
 }
 
-// Compact flattens the underlying data store for the given key range.
-func (ro *readonly) Compact(start []byte, limit []byte) error {
-	panic("readonly!")
-	return nil
+func (t *Readonly) Has(key []byte) (bool, error) {
+	return t.underlying.Has(prefixed(key, t.prefix))
 }
 
-// Close leaves underlying database.
-func (ro *readonly) Close() error {
-	panic("readonly!")
-	return nil
+func (t *Readonly) Get(key []byte) ([]byte, error) {
+	return t.underlying.Get(prefixed(key, t.prefix))
 }
 
-// NewBatch creates new batch.
-func (ro *readonly) NewBatch() kvdb.Batch {
-	panic("readonly!")
-	return nil
+func (t *Readonly) Stat(property string) (string, error) {
+	return t.underlying.Stat(property)
+}
+
+func (t *Readonly) NewIterator(itPrefix []byte, start []byte) kvdb.Iterator {
+	return &iterator{t.underlying.NewIterator(prefixed(itPrefix, t.prefix), start), t.prefix}
+}
+
+/*
+ * Iterator
+ */
+
+type iterator struct {
+	it     kvdb.Iterator
+	prefix []byte
+}
+
+func (it *iterator) Next() bool {
+	return it.it.Next()
+}
+
+func (it *iterator) Error() error {
+	return it.it.Error()
+}
+
+func (it *iterator) Key() []byte {
+	return noPrefix(it.it.Key(), it.prefix)
+}
+
+func (it *iterator) Value() []byte {
+	return it.it.Value()
+}
+
+func (it *iterator) Release() {
+	it.it.Release()
+	*it = iterator{}
 }

--- a/kvdb/table/readonly.go
+++ b/kvdb/table/readonly.go
@@ -1,0 +1,40 @@
+package table
+
+import (
+	"github.com/Fantom-foundation/lachesis-base/kvdb"
+)
+
+// readonly kvdb.Store panics on any data mutation.
+type readonly struct {
+	kvdb.ReadonlyStore
+}
+
+// Put puts key-value pair into the cache.
+func (ro *readonly) Put(key []byte, value []byte) error {
+	panic("readonly!")
+	return nil
+}
+
+// Delete removes key-value pair by key.
+func (ro *readonly) Delete(key []byte) error {
+	panic("readonly!")
+	return nil
+}
+
+// Compact flattens the underlying data store for the given key range.
+func (ro *readonly) Compact(start []byte, limit []byte) error {
+	panic("readonly!")
+	return nil
+}
+
+// Close leaves underlying database.
+func (ro *readonly) Close() error {
+	panic("readonly!")
+	return nil
+}
+
+// NewBatch creates new batch.
+func (ro *readonly) NewBatch() kvdb.Batch {
+	panic("readonly!")
+	return nil
+}

--- a/kvdb/table/table.go
+++ b/kvdb/table/table.go
@@ -4,10 +4,10 @@ import (
 	"github.com/Fantom-foundation/lachesis-base/kvdb"
 )
 
-// Table wraps the underling DB, so all the table's data is stored with a prefix in underling DB
+// Table wraper the underling DB, so all the table's data is stored with a prefix in underling DB
 type Table struct {
-	db     kvdb.Store
-	prefix []byte
+	Readonly
+	underlying kvdb.Store
 }
 
 var (
@@ -36,12 +36,13 @@ func noPrefix(key, prefix []byte) []byte {
  */
 
 func New(db kvdb.Store, prefix []byte) *Table {
-	return &Table{db, prefix}
-}
-
-func NewReadonly(rodb kvdb.ReadonlyStore, prefix []byte) *Table {
-	db := &readonly{rodb}
-	return &Table{db, prefix}
+	return &Table{
+		Readonly: Readonly{
+			prefix: prefix,
+			underlying:     db,
+		},
+		underlying: db,
+	}
 }
 
 func (t *Table) NewTable(prefix []byte) *Table {
@@ -55,66 +56,20 @@ func (t *Table) Close() error {
 // Drop the whole database.
 func (t *Table) Drop() {}
 
-func (t *Table) Has(key []byte) (bool, error) {
-	return t.db.Has(prefixed(key, t.prefix))
-}
-
-func (t *Table) Get(key []byte) ([]byte, error) {
-	return t.db.Get(prefixed(key, t.prefix))
-}
-
 func (t *Table) Put(key []byte, value []byte) error {
-	return t.db.Put(prefixed(key, t.prefix), value)
+	return t.underlying.Put(prefixed(key, t.prefix), value)
 }
 
 func (t *Table) Delete(key []byte) error {
-	return t.db.Delete(prefixed(key, t.prefix))
+	return t.underlying.Delete(prefixed(key, t.prefix))
 }
 
 func (t *Table) NewBatch() kvdb.Batch {
-	return &batch{t.db.NewBatch(), t.prefix}
-}
-
-func (t *Table) Stat(property string) (string, error) {
-	return t.db.Stat(property)
+	return &batch{t.underlying.NewBatch(), t.prefix}
 }
 
 func (t *Table) Compact(start []byte, limit []byte) error {
-	return t.db.Compact(start, limit)
-}
-
-/*
- * Iterator
- */
-
-type iterator struct {
-	it     kvdb.Iterator
-	prefix []byte
-}
-
-func (it *iterator) Next() bool {
-	return it.it.Next()
-}
-
-func (it *iterator) Error() error {
-	return it.it.Error()
-}
-
-func (it *iterator) Key() []byte {
-	return noPrefix(it.it.Key(), it.prefix)
-}
-
-func (it *iterator) Value() []byte {
-	return it.it.Value()
-}
-
-func (it *iterator) Release() {
-	it.it.Release()
-	*it = iterator{}
-}
-
-func (t *Table) NewIterator(itPrefix []byte, start []byte) kvdb.Iterator {
-	return &iterator{t.db.NewIterator(prefixed(itPrefix, t.prefix), start), t.prefix}
+	return t.underlying.Compact(start, limit)
 }
 
 /*

--- a/kvdb/table/table.go
+++ b/kvdb/table/table.go
@@ -39,6 +39,11 @@ func New(db kvdb.Store, prefix []byte) *Table {
 	return &Table{db, prefix}
 }
 
+func NewReadonly(rodb kvdb.ReadonlyStore, prefix []byte) *Table {
+	db := &readonly{rodb}
+	return &Table{db, prefix}
+}
+
 func (t *Table) NewTable(prefix []byte) *Table {
 	return New(t, prefix)
 }


### PR DESCRIPTION
New GetUnderlying() method of kvdb/flushable/SyncedPool returns readonly wrapper of underlying db.
It is for reading complete consistent and persistent (flushed) data.