### PR TITLE
Items fetcher instead of events fetcher

### DIFF
--- a/gossip/dagprocessor/processor.go
+++ b/gossip/dagprocessor/processor.go
@@ -4,9 +4,7 @@ import (
 	"errors"
 	"runtime"
 	"sync"
-	"time"
 
-	"github.com/Fantom-foundation/lachesis-base/gossip/dagfetcher"
 	"github.com/Fantom-foundation/lachesis-base/gossip/dagordering"
 	"github.com/Fantom-foundation/lachesis-base/hash"
 	"github.com/Fantom-foundation/lachesis-base/inter/dag"
@@ -49,8 +47,6 @@ type Callback struct {
 	Event EventCallback
 	// PeerMisbehaviour is a callback type for dropping a peer detected as malicious.
 	PeerMisbehaviour func(peer string, err error) bool
-
-	NotifyAnnounces func(peer string, ids hash.Events, time time.Time, fetchEvents dagfetcher.EventsRequesterFn) error
 }
 
 // New creates an event processor
@@ -111,7 +107,7 @@ type eventErrPair struct {
 	err   error
 }
 
-func (f *Processor) Enqueue(peer string, events dag.Events, ordered bool, time time.Time, fetchEvents dagfetcher.EventsRequesterFn, done chan struct{}) error {
+func (f *Processor) Enqueue(peer string, events dag.Events, ordered bool, notifyAnnounces func(hash.Events), done chan struct{}) error {
 	if !f.eventsSemaphore.Acquire(events.Metric(), f.cfg.EventsSemaphoreTimeout) {
 		return ErrBusy
 	}
@@ -161,8 +157,8 @@ func (f *Processor) Enqueue(peer string, events dag.Events, ordered bool, time t
 		}
 
 		// request unknown event parents
-		if len(toRequest) != 0 {
-			_ = f.callback.NotifyAnnounces(peer, toRequest, time, fetchEvents)
+		if notifyAnnounces != nil && len(toRequest) != 0 {
+			notifyAnnounces(toRequest)
 		}
 		if done != nil {
 			done <- struct{}{}

--- a/gossip/itemsfetcher/config.go
+++ b/gossip/itemsfetcher/config.go
@@ -1,4 +1,4 @@
-package dagfetcher
+package itemsfetcher
 
 import "time"
 

--- a/gossip/itemsfetcher/fetcher.go
+++ b/gossip/itemsfetcher/fetcher.go
@@ -1,4 +1,4 @@
-package dagfetcher
+package itemsfetcher
 
 import (
 	"errors"
@@ -6,91 +6,85 @@ import (
 	"sync"
 	"time"
 
-	"github.com/Fantom-foundation/lachesis-base/hash"
 	"github.com/Fantom-foundation/lachesis-base/utils/wlru"
 	"github.com/Fantom-foundation/lachesis-base/utils/workers"
 )
 
 /*
- * Fetcher is a network agent, which handles basic hash-based events sync.
+ * Fetcher is a network agent, which handles basic hash-based items sync.
  * The core mechanic is very simple: interested hash arrived => request it.
  * Fetcher has additional code to protect itself (and other nodes) against DoS.
  */
 
 var (
-	errTerminated       = errors.New("terminated")
-	ErrTooManyAnnounces = errors.New("peer exceeded outstanding announces")
+	errTerminated = errors.New("terminated")
 )
 
-// PeerMisbehaviourFn is a callback type for dropping a peer detected as malicious.
-type PeerMisbehaviourFn func(peer string, err error) bool
-
-// EventsRequesterFn is a callback type for sending a event retrieval request.
-type EventsRequesterFn func(hash.Events) error
+// ItemsRequesterFn is a callback type for sending a item retrieval request.
+type ItemsRequesterFn func([]interface{}) error
 
 type announceData struct {
-	time        time.Time // Timestamp of the announcement
-	peer        string    // Identifier of the peer originating the notification
-	fetchEvents EventsRequesterFn
+	time       time.Time // Timestamp of the announcement
+	peer       string    // Identifier of the peer originating the notification
+	fetchItems ItemsRequesterFn
 }
 
 type announcesBatch struct {
 	announceData
-	ids hash.Events // Hashes of the events being announced
+	ids []interface{} // Hashes of the items being announced
 }
 
-type fetchingEvent struct {
+type fetchingItem struct {
 	announce     announceData
 	fetchingTime time.Time
 }
 
-// Fetcher is responsible for accumulating event announcements from various peers
+// Fetcher is responsible for accumulating item announcements from various peers
 // and scheduling them for retrieval.
 type Fetcher struct {
 	cfg Config
 
-	// Various event channels
-	notifications  chan announcesBatch
-	receivedEvents chan hash.Events
-	quit           chan struct{}
+	// Various item channels
+	notifications chan announcesBatch
+	receivedItems chan []interface{}
+	quit          chan struct{}
 
 	// Callbacks
 	callback Callback
 
 	// Announce states
-	announces *wlru.Cache // Announced events, scheduled for fetching
+	announces *wlru.Cache // Announced items, scheduled for fetching
 
-	fetching map[hash.Event]fetchingEvent // Announced events, currently fetching
+	fetching map[interface{}]fetchingItem // Announced items, currently fetching
 	wg       sync.WaitGroup
 
 	parallelTasks *workers.Workers
 }
 
 type Callback struct {
-	// FilterInterested returns only event which may be requested.
-	OnlyInterested func(ids hash.Events) hash.Events
-	// PeerMisbehaviour is a callback type for dropping a peer detected as malicious.
-	PeerMisbehaviour func(peer string, err error) bool
+	// FilterInterested returns only item which may be requested.
+	OnlyInterested func(ids []interface{}) []interface{}
+	Suspend        func() bool
 }
 
-// New creates a event fetcher to retrieve events based on hash announcements.
+// New creates a item fetcher to retrieve items based on hash announcements.
 func New(cfg Config, callback Callback) *Fetcher {
 	f := &Fetcher{
-		cfg:            cfg,
-		notifications:  make(chan announcesBatch, cfg.MaxQueuedBatches),
-		receivedEvents: make(chan hash.Events, cfg.MaxQueuedBatches),
-		quit:           make(chan struct{}),
-		fetching:       make(map[hash.Event]fetchingEvent),
-		callback:       callback,
+		cfg:           cfg,
+		notifications: make(chan announcesBatch, cfg.MaxQueuedBatches),
+		receivedItems: make(chan []interface{}, cfg.MaxQueuedBatches),
+		quit:          make(chan struct{}),
+		fetching:      make(map[interface{}]fetchingItem),
+		callback:      callback,
 	}
 	f.announces, _ = wlru.NewWithEvict(uint(cfg.HashLimit), cfg.HashLimit, func(key interface{}, _ interface{}) {
-		delete(f.fetching, key.(hash.Event))
+		delete(f.fetching, key.(interface{}))
 	})
 	f.parallelTasks = workers.New(&f.wg, f.quit, f.cfg.MaxParallelRequests*2)
 	return f
 }
 
-// Start boots up the events fetcher.
+// Start boots up the items fetcher.
 func (f *Fetcher) Start() {
 	f.parallelTasks.Start(f.cfg.MaxParallelRequests)
 	f.wg.Add(1)
@@ -108,16 +102,16 @@ func (f *Fetcher) Stop() {
 	f.wg.Wait()
 }
 
-// Overloaded returns true if too much events are being requested
+// Overloaded returns true if too much items are being requested
 func (f *Fetcher) Overloaded() bool {
-	return len(f.receivedEvents) > f.cfg.MaxQueuedBatches*3/4 ||
+	return len(f.receivedItems) > f.cfg.MaxQueuedBatches*3/4 ||
 		len(f.notifications) > f.cfg.MaxQueuedBatches*3/4 ||
 		f.announces.Len() > f.cfg.HashLimit*3/4
 }
 
-// NotifyAnnounces announces the fetcher of the potential availability of a new event in
+// NotifyAnnounces announces the fetcher of the potential availability of a new item in
 // the network.
-func (f *Fetcher) NotifyAnnounces(peer string, ids hash.Events, time time.Time, fetchEvents EventsRequesterFn) error {
+func (f *Fetcher) NotifyAnnounces(peer string, ids []interface{}, time time.Time, fetchItems ItemsRequesterFn) error {
 	// divide big batch into smaller ones
 	for start := 0; start < len(ids); start += f.cfg.MaxBatch {
 		end := len(ids)
@@ -126,9 +120,9 @@ func (f *Fetcher) NotifyAnnounces(peer string, ids hash.Events, time time.Time, 
 		}
 		op := announcesBatch{
 			announceData: announceData{
-				time:        time,
-				peer:        peer,
-				fetchEvents: fetchEvents,
+				time:       time,
+				peer:       peer,
+				fetchItems: fetchItems,
 			},
 			ids: ids[start:end],
 		}
@@ -142,7 +136,7 @@ func (f *Fetcher) NotifyAnnounces(peer string, ids hash.Events, time time.Time, 
 	return nil
 }
 
-func (f *Fetcher) NotifyReceived(ids hash.Events) error {
+func (f *Fetcher) NotifyReceived(ids []interface{}) error {
 	// divide big batch into smaller ones
 	for start := 0; start < len(ids); start += f.cfg.MaxBatch {
 		end := len(ids)
@@ -152,14 +146,14 @@ func (f *Fetcher) NotifyReceived(ids hash.Events) error {
 		select {
 		case <-f.quit:
 			return errTerminated
-		case f.receivedEvents <- ids[start:end]:
+		case f.receivedItems <- ids[start:end]:
 			continue
 		}
 	}
 	return nil
 }
 
-func (f *Fetcher) getAnnounces(id hash.Event) []announceData {
+func (f *Fetcher) getAnnounces(id interface{}) []announceData {
 	announces, ok := f.announces.Get(id)
 	if !ok {
 		return []announceData{}
@@ -176,7 +170,9 @@ func (f *Fetcher) processNotification(notification announcesBatch, fetchTimer *t
 		return
 	}
 
-	toFetch := make(hash.Events, 0, len(notification.ids))
+	noFetching := f.callback.Suspend()
+
+	toFetch := make([]interface{}, 0, len(notification.ids))
 	now := time.Now()
 	for _, id := range notification.ids {
 		// add new announcement. other peers may already have announced it, so it's an array
@@ -184,20 +180,22 @@ func (f *Fetcher) processNotification(notification announcesBatch, fetchTimer *t
 		anns = append(anns, notification.announceData)
 		f.announces.Add(id, append(anns, notification.announceData), uint(len(anns)))
 		// if it wasn't announced before, then schedule for fetching this time
-		if _, ok := f.fetching[id]; !ok {
-			f.fetching[id] = fetchingEvent{
-				announce:     notification.announceData,
-				fetchingTime: now,
+		if !noFetching {
+			if _, ok := f.fetching[id]; !ok {
+				f.fetching[id] = fetchingItem{
+					announce:     notification.announceData,
+					fetchingTime: now,
+				}
+				toFetch = append(toFetch, id)
 			}
-			toFetch.Add(id)
 		}
 	}
 
 	if len(toFetch) != 0 {
 		// Create a closure of the fetch and schedule in on a new thread
-		fetchEvents, hashes := notification.fetchEvents, toFetch
+		fetchItems, hashes := notification.fetchItems, toFetch
 		_ = f.parallelTasks.Enqueue(func() {
-			_ = fetchEvents(hashes)
+			_ = fetchItems(hashes)
 		})
 	}
 
@@ -208,12 +206,12 @@ func (f *Fetcher) processNotification(notification announcesBatch, fetchTimer *t
 
 // Loop is the main fetcher loop, checking and processing various notifications
 func (f *Fetcher) loop() {
-	// Iterate the event fetching until a quit is requested
+	// Iterate the item fetching until a quit is requested
 	fetchTimer := time.NewTimer(0)
 	defer fetchTimer.Stop()
 
 	for {
-		// Wait for an outside event to occur
+		// Wait for an outside item to occur
 		select {
 		case <-f.quit:
 			// Fetcher terminating, abort all operations
@@ -222,27 +220,27 @@ func (f *Fetcher) loop() {
 		case notification := <-f.notifications:
 			f.processNotification(notification, fetchTimer)
 
-		case ids := <-f.receivedEvents:
+		case ids := <-f.receivedItems:
 			for _, id := range ids {
 				f.forgetHash(id)
 			}
 
 		case <-fetchTimer.C:
 			now := time.Now()
-			// At least one event's timer ran out, check for needing retrieval
-			request := make(map[string]hash.Events)
-			requestFns := make(map[string]EventsRequesterFn)
+			// At least one item's timer ran out, check for needing retrieval
+			request := make(map[string][]interface{})
+			requestFns := make(map[string]ItemsRequesterFn)
 
-			// Find not arrived events
-			all := make(hash.Events, 0, f.announces.Len())
-			for _, e := range f.announces.Keys() {
-				all.Add(e.(hash.Event))
+			// Find not arrived items
+			all := make([]interface{}, 0, f.announces.Len())
+			for _, id := range f.announces.Keys() {
+				all = append(all, id)
 			}
 			notArrived := f.callback.OnlyInterested(all)
 
-			for _, e := range notArrived {
-				// Re-fetch not arrived events
-				announces := f.getAnnounces(e)
+			for _, id := range notArrived {
+				// Re-fetch not arrived items
+				announces := f.getAnnounces(id)
 				if len(announces) == 0 {
 					continue
 				}
@@ -250,38 +248,41 @@ func (f *Fetcher) loop() {
 				oldest := announces[0] // first is the oldest
 				if time.Since(oldest.time) > f.cfg.ForgetTimeout {
 					// Forget too old announces
-					f.forgetHash(e)
-				} else if time.Since(f.fetching[e].fetchingTime) > f.cfg.ArriveTimeout-f.cfg.GatherSlack {
-					// The event still didn't arrive, queue for fetching from a random peer
+					f.forgetHash(id)
+				} else if time.Since(f.fetching[id].fetchingTime) > f.cfg.ArriveTimeout-f.cfg.GatherSlack {
+					// The item still didn't arrive, queue for fetching from a random peer
 					announce := announces[rand.Intn(len(announces))]
-					request[announce.peer] = append(request[announce.peer], e)
-					requestFns[announce.peer] = announce.fetchEvents
-					f.fetching[e] = fetchingEvent{
+					request[announce.peer] = append(request[announce.peer], id)
+					requestFns[announce.peer] = announce.fetchItems
+					f.fetching[id] = fetchingItem{
 						announce:     announce,
 						fetchingTime: now,
 					}
 				}
 			}
 
-			// Forget arrived events.
-			// It's possible to get here only if event arrived out-of-fetcher, via another channel.
+			// Forget arrived items.
+			// It's possible to get here only if item arrived out-of-fetcher, via another channel.
 			// Also may be possible after a change of an epoch.
-			notArrivedM := notArrived.Set()
-			for _, e := range all {
-				if !notArrivedM.Contains(e) {
-					f.forgetHash(e)
+			notArrivedMap := make(map[interface{}]bool, len(notArrived))
+			for _, id := range notArrived {
+				notArrivedMap[id] = true
+			}
+			for _, id := range all {
+				if !notArrivedMap[id] {
+					f.forgetHash(id)
 				}
 			}
 
-			// Send out all event requests
+			// Send out all item requests
 			for peer, req := range request {
 				// Create a closure of the fetch and schedule in on a new thread
-				fetchEvents, hashes := requestFns[peer], req
+				fetchItems, hashes := requestFns[peer], req
 				_ = f.parallelTasks.Enqueue(func() {
-					_ = fetchEvents(hashes)
+					_ = fetchItems(hashes)
 				})
 			}
-			// Schedule the next fetch if events are still pending
+			// Schedule the next fetch if items are still pending
 			f.rescheduleFetch(fetchTimer)
 		}
 	}
@@ -289,7 +290,7 @@ func (f *Fetcher) loop() {
 
 // rescheduleFetch resets the specified fetch timer to the next announce timeout.
 func (f *Fetcher) rescheduleFetch(fetch *time.Timer) {
-	// Short circuit if no events are announced
+	// Short circuit if no items are announced
 	if f.announces.Len() == 0 {
 		return
 	}
@@ -303,8 +304,8 @@ func (f *Fetcher) rescheduleFetch(fetch *time.Timer) {
 	fetch.Reset(f.cfg.ArriveTimeout - time.Since(earliest))
 }
 
-// forgetHash removes all traces of a event announcement from the fetcher's
+// forgetHash removes all traces of a item announcement from the fetcher's
 // internal state.
-func (f *Fetcher) forgetHash(id hash.Event) {
+func (f *Fetcher) forgetHash(id interface{}) {
 	f.announces.Remove(id) // f.fetching is deleted inside the evict callback
 }

--- a/hash/hash.go
+++ b/hash/hash.go
@@ -5,6 +5,7 @@ import (
 	"math/big"
 	"math/rand"
 	"reflect"
+	"strings"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -23,6 +24,10 @@ var (
 
 // Hash represents the 32 byte hash of arbitrary data.
 type Hash [HashLength]byte
+
+type Hashes []Hash
+
+type HashesSet map[Hash]struct{}
 
 // BytesToHash sets b to hash.
 // If b is larger than len(h), b will be cropped from the left.
@@ -107,4 +112,117 @@ func FakeHash(seed ...int64) (h common.Hash) {
 		panic(err)
 	}
 	return
+}
+
+/*
+ * HashesSet methods:
+ */
+
+// NewHashesSet makes hash index.
+func NewHashesSet(h ...Hash) HashesSet {
+	hh := HashesSet{}
+	hh.Add(h...)
+	return hh
+}
+
+// Copy copies hashes to a new structure.
+func (hh HashesSet) Copy() HashesSet {
+	ee := make(HashesSet, len(hh))
+	for k, v := range hh {
+		ee[k] = v
+	}
+
+	return ee
+}
+
+// String returns human readable string representation.
+func (hh HashesSet) String() string {
+	ss := make([]string, 0, len(hh))
+	for h := range hh {
+		ss = append(ss, h.String())
+	}
+	return "[" + strings.Join(ss, ", ") + "]"
+}
+
+// Slice returns whole index as slice.
+func (hh HashesSet) Slice() Hashes {
+	arr := make(Hashes, len(hh))
+	i := 0
+	for h := range hh {
+		arr[i] = h
+		i++
+	}
+	return arr
+}
+
+// Add appends hash to the index.
+func (hh HashesSet) Add(hash ...Hash) (changed bool) {
+	for _, h := range hash {
+		if _, ok := hh[h]; !ok {
+			hh[h] = struct{}{}
+			changed = true
+		}
+	}
+	return
+}
+
+// Erase erase hash from the index.
+func (hh HashesSet) Erase(hash ...Hash) (changed bool) {
+	for _, h := range hash {
+		if _, ok := hh[h]; ok {
+			delete(hh, h)
+			changed = true
+		}
+	}
+	return
+}
+
+// Contains returns true if hash is in.
+func (hh HashesSet) Contains(hash Hash) bool {
+	_, ok := hh[hash]
+	return ok
+}
+
+/*
+ * Hashes methods:
+ */
+
+// NewHashes makes hash slice.
+func NewHashes(h ...Hash) Hashes {
+	hh := Hashes{}
+	hh.Add(h...)
+	return hh
+}
+
+// Copy copies hashes to a new structure.
+func (hh Hashes) Copy() Hashes {
+	ee := make(Hashes, len(hh))
+	for k, v := range hh {
+		ee[k] = v
+	}
+
+	return ee
+}
+
+// String returns human readable string representation.
+func (hh Hashes) String() string {
+	ss := make([]string, 0, len(hh))
+	for _, h := range hh {
+		ss = append(ss, h.String())
+	}
+	return "[" + strings.Join(ss, ", ") + "]"
+}
+
+// Set returns whole index as a HashesSet.
+func (hh Hashes) Set() HashesSet {
+	set := make(HashesSet, len(hh))
+	for _, h := range hh {
+		set[h] = struct{}{}
+	}
+	return set
+}
+
+// Add appends hash to the slice.
+func (hh *Hashes) Add(hash ...Hash) {
+	*hh = append(*hh, hash...)
 }


### PR DESCRIPTION
- adjust events fetcher to work with interface{} instead of hash.Event, thus making it usable for general fetching