### PR TITLE
Refactor lite configs

### DIFF
--- a/abft/config.go
+++ b/abft/config.go
@@ -5,12 +5,12 @@ import "github.com/Fantom-foundation/lachesis-base/utils/cachescale"
 type Config struct {
 }
 
-// DefaultStoreConfig for livenet.
+// DefaultConfig for livenet.
 func DefaultConfig() Config {
 	return Config{}
 }
 
-// LiteStoreConfig is for tests or inmemory.
+// LiteConfig is for tests or inmemory.
 func LiteConfig() Config {
 	return Config{}
 }
@@ -39,10 +39,5 @@ func DefaultStoreConfig(scale cachescale.Func) StoreConfig {
 
 // LiteStoreConfig is for tests or inmemory.
 func LiteStoreConfig() StoreConfig {
-	return StoreConfig{
-		StoreCacheConfig{
-			RootsNum:    50,
-			RootsFrames: 10,
-		},
-	}
+	return DefaultStoreConfig(cachescale.Ratio{Base: 20, Target: 1})
 }

--- a/utils/cachescale/ratio.go
+++ b/utils/cachescale/ratio.go
@@ -16,7 +16,11 @@ var _ Func = (*Ratio)(nil)
 var Identity = Ratio{1, 1}
 
 func (r Ratio) U64(v uint64) uint64 {
-	return v * r.Target / r.Base
+	muled := v * r.Target
+	if muled%r.Base == 0 {
+		return muled / r.Base
+	}
+	return muled/r.Base + 1
 }
 
 func (r Ratio) F32(v float32) float32 {

--- a/vecfc/index.go
+++ b/vecfc/index.go
@@ -24,7 +24,7 @@ type IndexConfig struct {
 	Caches IndexCacheConfig
 }
 
-// Engine is a data to detect forkless-cause condition, calculate median timestamp, detect forks.
+// Index is a data to detect forkless-cause condition, calculate median timestamp, detect forks.
 type Index struct {
 	*vecengine.Engine
 
@@ -62,13 +62,7 @@ func DefaultConfig(scale cachescale.Func) IndexConfig {
 
 // LiteConfig returns default index config for tests
 func LiteConfig() IndexConfig {
-	return IndexConfig{
-		Caches: IndexCacheConfig{
-			ForklessCausePairs:   500,
-			HighestBeforeSeqSize: 4 * 1024,
-			LowestAfterSeqSize:   4 * 1024,
-		},
-	}
+	return DefaultConfig(cachescale.Ratio{Base: 100, Target: 1})
 }
 
 // NewIndex creates Index instance.


### PR DESCRIPTION
- cachescale rounds cache upwards
- LiteConfig uses cachescale below 1.0