### PR TITLE
Fix election unit tests

### DIFF
--- a/abft/election/election_test.go
+++ b/abft/election/election_test.go
@@ -62,7 +62,7 @@ a2_2══╬═════╬═════╣
 		testProcessRoot(t,
 			&testExpected{
 				DecidedFrame:   0,
-				DecidedAtropos: "b0_0",
+				DecidedAtropos: "d0_0",
 				DecisiveRoots:  map[string]bool{"a2_2": true},
 			},
 			weights{
@@ -90,7 +90,7 @@ a2_2══╬═════╬═════╣
 		testProcessRoot(t,
 			&testExpected{
 				DecidedFrame:   0,
-				DecidedAtropos: "b0_0",
+				DecidedAtropos: "a0_0",
 				DecisiveRoots:  map[string]bool{"a2_2": true},
 			},
 			weights{
@@ -145,7 +145,7 @@ a1_1══╬═════╣     ║
 			&testExpected{
 				DecidedFrame:   0,
 				DecidedAtropos: "a0_0",
-				DecisiveRoots:  map[string]bool{"a4_4": true},
+				DecisiveRoots:  map[string]bool{"c2_2": true},
 			},
 			weights{
 				"nodeA": 4,

--- a/inter/dag/tdag/events.go
+++ b/inter/dag/tdag/events.go
@@ -57,9 +57,9 @@ func (ee TestEvents) ByParents() (res TestEvents) {
 		unsorted[i] = e
 	}
 	sorted := ByParents(unsorted)
-	testSorted := make(TestEvents, len(ee))
+	res = make(TestEvents, len(ee))
 	for i, e := range sorted {
-		testSorted[i] = e.(*TestEvent)
+		res[i] = e.(*TestEvent)
 	}
 
 	return


### PR DESCRIPTION
I found error in a test-only function in events.go that made all election_test tests pass without actually testing anything (Introduced in - decouple consensus algorithm from Opera chain ca69f3383). This bug made it so that the tests added in ca69f3383 (election_test.go) never actually tested the elections, they operated on an empty array of events.

Please check if what you want to add to `lachesis-base` list meets [quality standards](https://github.com/Fantom-foundation/lachesis-base/blob/master/CONTRIBUTING.md#quality-standard) before sending pull request.

**Please provide package links to:**

- github.com repo: https://github.com/0xPoos/lachesis-base/tree/election-test-fixes
- godoc.org: https://pkg.go.dev/github.com/Fantom-foundation/lachesis-base@v0.0.0-20210721130657-54ad3c8a18c1/abft/election
- goreportcard.com: https://goreportcard.com/report/github.com/Fantom-foundation/lachesis-base
- coverage service link ([cover.run](https://cover.run/), [gocover](http://gocover.io/), [coveralls](https://coveralls.io/) etc.), example: `[![cover.run](https://cover.run/go/github.com/user/repository.svg?style=flat&tag=golang-1.10)](https://cover.run/go?tag=golang-1.10&repo=github.com%2Fuser%2Frepository)`: https://gocover.io/https://github.com/0xPoos/lachesis-base

**Make sure that you've checked the boxes below before you submit PR:**
- [X] I have added my package in alphabetical order.
- [X] I have an appropriate description with correct grammar.
- [X] I know that this package was not listed before.
- [X] I have added godoc link to the repo and to my pull request.
- [X] I have added coverage service link to the repo and to my pull request.
- [X] I have added goreportcard link to the repo and to my pull request.
- [X] I have read [Contribution guidelines](https://github.com/Fantom-foundation/lachesis-base/blob/master/CONTRIBUTING.md#contribution-guidelines), [maintainers note](https://github.com/Fantom-foundation/lachesis-base/blob/master/CONTRIBUTING.md#maintainers) and [Quality standard](https://github.com/Fantom-foundation/lachesis-base/blob/master/CONTRIBUTING.md#quality-standard).
