### PR TITLE
remove an If check that can never pass from election_math.go

### DIFF
--- a/abft/election/election_math.go
+++ b/abft/election/election_math.go
@@ -21,10 +21,6 @@ func (el *Election) ProcessRoot(newRoot RootAndSlot) (*Res, error) {
 		return nil, nil
 	}
 	round := newRoot.Slot.Frame - el.frameToDecide
-	if round == 0 {
-		return nil, nil
-	}
-
 	notDecidedRoots := el.notDecidedRoots()
 
 	var observedRoots []RootAndSlot


### PR DESCRIPTION
In election_math.go function ProcessRoot, the if check for round == 0 can never be true

1. Both newRoot.Slot.Frame and el.frameToDecide are of type idx.Frame
2. idx.Frame is a uint
3. if both newRoot.Slot.Frame and el.frameToDecide are their lowest possible values, 0, they will return due to the check at line 19
4. for round to be == 0, newRoot.Slot.Frame == el.frameToDecide, which is already checked at line 19
5. the if check at line 24 is impossible to pass


