### PR TITLE
Pebble database flushing

### DIFF
--- a/kvdb/pebble/pebble.go
+++ b/kvdb/pebble/pebble.go
@@ -80,6 +80,12 @@ func (db *Database) Drop() {
 	}
 }
 
+// AsyncFlush asynchronously flushes the in-memory buffer to the disk.
+func (db *Database) AsyncFlush() error {
+	_, err := db.underlying.AsyncFlush()
+	return err
+}
+
 // Has retrieves if a key is present in the key-value store.
 func (db *Database) Has(key []byte) (bool, error) {
 	_, closer, err := db.underlying.Get(key)


### PR DESCRIPTION
Pebble database support - add function for flushing in-memory write buffer to the disk.

The new function `AsyncFlush()` needs to be called when SyncedPool finish its flush - after setting the CleanPrefix.