### PR TITLE
correct the pebble total written bytes

### DIFF
--- a/kvdb/pebble/pebble.go
+++ b/kvdb/pebble/pebble.go
@@ -197,9 +197,10 @@ func bytesPrefix(prefix []byte) pebble.IterOptions {
 func (db *Database) Stat(property string) (string, error) {
 	// only "leveldb." prefix is accessible using debug.chaindbProperty
 	if property == "leveldb.iostats" {
+		total := db.underlying.Metrics().Total()
 		return fmt.Sprintf("Read(MB):%.5f Write(MB):%.5f",
-			float64(db.underlying.Metrics().Total().BytesRead)/1048576.0, // 1024*1024
-			float64(db.underlying.Metrics().Total().BytesIn)/1048576.0), nil
+			float64(total.BytesRead)/1048576.0, // 1024*1024
+			float64(total.BytesFlushed+total.BytesCompacted)/1048576.0), nil
 	}
 	if property == "leveldb.metrics" {
 		return db.underlying.Metrics().String(), nil


### PR DESCRIPTION
According to the pebble document, I think the total written bytes should be = `BytesFlushed` + `BytesCompacted`

```
	// The number of bytes written during compactions. The sibling
	// metric for tables is TablesCompacted. This metric may be summed
	// with BytesFlushed to compute the total bytes written for the level.
	BytesCompacted uint64
```