### PR TITLE
Pebble - allow 3 concurrent compactions for performant imports

### DIFF
--- a/kvdb/pebble/pebble.go
+++ b/kvdb/pebble/pebble.go
@@ -26,10 +26,11 @@ type Database struct {
 // metrics reporting should use for surfacing internal stats.
 func New(path string, cache int, close func() error, drop func()) (*Database, error) {
 	db, err := pebble.Open(path, &pebble.Options{
-		Cache:           pebble.NewCache(int64(cache / 2)), // default 8 MB
-		MemTableSize:    cache / 4,                         // default 4 MB
-		MaxOpenFiles:    1000,                              // default 1000
-		WALBytesPerSync: 0,                                 // default 0 (matches RocksDB = no background syncing)
+		Cache:                    pebble.NewCache(int64(cache / 2)), // default 8 MB
+		MemTableSize:             cache / 4,                         // default 4 MB
+		MaxOpenFiles:             1000,                              // default 1000
+		WALBytesPerSync:          0,                                 // default 0 (matches RocksDB = no background syncing)
+		MaxConcurrentCompactions: 3,                                 // default 1, important for big imports performance
 	})
 
 	if err != nil {


### PR DESCRIPTION
Pebble inserting performance drops down when importing big amount of data. This is fixed by allowing multiple parallel compact operations running in the Pebble. The value `3` proved to have the best results in benchmarks and is also used by Cockroach (company developing the Pebble database) for their production use.

This solution emerged from my pebble ticket https://github.com/cockroachdb/pebble/issues/1691 and is confirmed by my benchmark.

Benchmarking results: (MaxConcurrentCompactions value in annotations)
https://grafana.fantom.network/d/JcHgD5gVk/pebble-benchmark-without-opera?orgId=1&from=1658297175262&to=1658413199912
(compared 1 thread, 10 threads, 5 threads and 3 threads - performance drops only for 1 thread, on the other hand, 5 or 10 threads has unnecessary overhead which slows the inserts down)