### PR TITLE
Optimize DBs wrapping

### DIFF
--- a/abft/election/election_math.go
+++ b/abft/election/election_math.go
@@ -22,6 +22,7 @@ func (el *Election) ProcessRoot(newRoot RootAndSlot) (*Res, error) {
 	}
 	round := newRoot.Slot.Frame - el.frameToDecide
 	if round == 0 {
+		// unreachable because of condition above
 		return nil, nil
 	}
 

--- a/kvdb/flaggedproducer/producer.go
+++ b/kvdb/flaggedproducer/producer.go
@@ -1,0 +1,103 @@
+package flaggedproducer
+
+import (
+	"errors"
+	"sync"
+	"sync/atomic"
+
+	"github.com/Fantom-foundation/lachesis-base/kvdb"
+	"github.com/Fantom-foundation/lachesis-base/kvdb/flushable"
+)
+
+type Producer struct {
+	backend    kvdb.IterableDBProducer
+	mu         sync.Mutex
+	dbs        map[string]*flaggedStore
+	flushIDKey []byte
+}
+
+func Wrap(backend kvdb.IterableDBProducer, flushIDKey []byte) *Producer {
+	return &Producer{
+		backend:    backend,
+		dbs:        make(map[string]*flaggedStore),
+		flushIDKey: flushIDKey,
+	}
+}
+
+func (f *Producer) OpenDB(name string) (kvdb.Store, error) {
+	// open existing DB
+	f.mu.Lock()
+	openedDB := f.dbs[name]
+	f.mu.Unlock()
+	if openedDB != nil {
+		return openedDB, nil
+	}
+	// create new DB
+	db, err := f.backend.OpenDB(name)
+	if err != nil {
+		return nil, err
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.dbs[name] != nil {
+		return nil, errors.New("already opened")
+	}
+	flagged := &flaggedStore{
+		Store: db,
+		DropFn: func() {
+			f.mu.Lock()
+			delete(f.dbs, name)
+			f.mu.Unlock()
+			_ = db.Close()
+			db.Drop()
+		},
+		Dirty:      0,
+		flushIDKey: f.flushIDKey,
+	}
+	f.dbs[name] = flagged
+	return flagged, nil
+}
+
+func (f *Producer) Names() []string {
+	return f.backend.Names()
+}
+
+func (f *Producer) NotFlushedSizeEst() int {
+	return 0
+}
+
+func (f *Producer) Flush(id []byte) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for _, db := range f.dbs {
+		err := flushable.MarkFlushID(db, f.flushIDKey, flushable.CleanPrefix, id)
+		if err != nil {
+			return err
+		}
+		atomic.StoreUint32(&db.Dirty, 0)
+	}
+	return nil
+}
+
+func (f *Producer) Initialize(dbNames []string, flushID []byte) ([]byte, error) {
+	dbs := map[string]kvdb.Store{}
+	for _, name := range dbNames {
+		db, err := f.OpenDB(name)
+		if err != nil {
+			return flushID, err
+		}
+		dbs[name] = db
+	}
+	return flushable.CheckDBsSynced(dbs, f.flushIDKey, flushID)
+}
+
+func (f *Producer) Close() error {
+	for _, db := range f.dbs {
+		err := db.Store.Close()
+		if err != nil {
+			return err
+		}
+	}
+	f.dbs = nil
+	return nil
+}

--- a/kvdb/flaggedproducer/store.go
+++ b/kvdb/flaggedproducer/store.go
@@ -1,0 +1,70 @@
+package flaggedproducer
+
+import (
+	"sync/atomic"
+
+	"github.com/Fantom-foundation/lachesis-base/kvdb"
+	"github.com/Fantom-foundation/lachesis-base/kvdb/flushable"
+)
+
+type flaggedStore struct {
+	kvdb.Store
+	DropFn     func()
+	Dirty      uint32
+	flushIDKey []byte
+}
+
+type flaggedBatch struct {
+	kvdb.Batch
+	db *flaggedStore
+}
+
+func (s *flaggedStore) Close() error {
+	return nil
+}
+
+func (s *flaggedStore) Drop() {
+	s.DropFn()
+}
+
+func (s *flaggedStore) modified() error {
+	if atomic.LoadUint32(&s.Dirty) == 0 {
+		atomic.StoreUint32(&s.Dirty, 1)
+		err := s.Store.Put(s.flushIDKey, []byte{flushable.DirtyPrefix})
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *flaggedStore) Put(key []byte, value []byte) error {
+	err := s.modified()
+	if err != nil {
+		return err
+	}
+	return s.Store.Put(key, value)
+}
+
+func (s *flaggedStore) Delete(key []byte) error {
+	err := s.modified()
+	if err != nil {
+		return err
+	}
+	return s.Store.Delete(key)
+}
+
+func (s *flaggedStore) NewBatch() kvdb.Batch {
+	return &flaggedBatch{
+		Batch: s.Store.NewBatch(),
+		db:    s,
+	}
+}
+
+func (s *flaggedBatch) Write() error {
+	err := s.db.modified()
+	if err != nil {
+		return err
+	}
+	return s.Batch.Write()
+}

--- a/kvdb/flushable/flushable_test.go
+++ b/kvdb/flushable/flushable_test.go
@@ -395,8 +395,8 @@ func benchmarkFlushable(db *Flushable, goroutines, recs, flushPeriod int, readin
 	wg.Wait()
 }
 
-func cache16mb(string) int {
-	return 16 * opt.MiB
+func cache16mb(string) (int, int) {
+	return 16 * opt.MiB, 64
 }
 
 func dbProducer(name string) kvdb.DBProducer {

--- a/kvdb/flushable/synced_pool.go
+++ b/kvdb/flushable/synced_pool.go
@@ -193,7 +193,7 @@ func (p *SyncedPool) Flush(id []byte) error {
 func (p *SyncedPool) flush(id []byte) error {
 	queuedClosesMap := p.popQueuedCloses()
 	queuedDropsList := p.popQueuedDrops()
-	// drop (and close if queued) old DBs
+	// drop (and close if queued) DBs
 	for _, name := range queuedDropsList {
 		w := p.wrappers[name]
 		delete(p.wrappers, name)
@@ -259,7 +259,7 @@ func (p *SyncedPool) flush(id []byte) error {
 		}
 	}
 
-	// close DBs which were both closed but not dropped
+	// close DBs which were closed but not dropped
 	for name := range queuedClosesMap {
 		w := p.wrappers[name]
 		delete(p.wrappers, name)

--- a/kvdb/flushable/synced_pool.go
+++ b/kvdb/flushable/synced_pool.go
@@ -248,6 +248,7 @@ func CheckDBsSynced(dbs map[string]kvdb.Store, flushIDKey, flushID []byte) ([]by
 		list   = func() string {
 			return strings.Join(descrs, ", ")
 		}
+		nonInit bool
 	)
 	for name, db := range dbs {
 		mark, err := db.Get(flushIDKey)
@@ -255,7 +256,8 @@ func CheckDBsSynced(dbs map[string]kvdb.Store, flushIDKey, flushID []byte) ([]by
 			return flushID, err
 		}
 		if mark == nil {
-			return flushID, fmt.Errorf("nin-initialized DB state: %s", name)
+			nonInit = true
+			continue
 		}
 		descrs = append(descrs, fmt.Sprintf("%s: %s", name, hexutils.BytesToHex(mark)))
 
@@ -268,6 +270,9 @@ func CheckDBsSynced(dbs map[string]kvdb.Store, flushIDKey, flushID []byte) ([]by
 		if !bytes.Equal(mark, flushID) {
 			return flushID, fmt.Errorf("not synced: %s != %s", hexutils.BytesToHex(flushID), list())
 		}
+	}
+	if flushID != nil && nonInit {
+		return flushID, fmt.Errorf("non-initialized DB state")
 	}
 	return flushID, nil
 }

--- a/kvdb/interface.go
+++ b/kvdb/interface.go
@@ -126,7 +126,13 @@ type FlushableDBProducer interface {
 	Flush(id []byte) error
 }
 
-type FullDBProducer interface {
+type ScopedFlushableProducer interface {
 	FlushableDBProducer
+	Initialize(dbNames []string, flushID []byte) ([]byte, error)
+	Close() error
+}
+
+type FullDBProducer interface {
+	ScopedFlushableProducer
 	IterableDBProducer
 }

--- a/kvdb/leveldb/leveldb.go
+++ b/kvdb/leveldb/leveldb.go
@@ -13,6 +13,7 @@ import (
 	"github.com/syndtr/goleveldb/leveldb/util"
 
 	"github.com/Fantom-foundation/lachesis-base/kvdb"
+	"github.com/Fantom-foundation/lachesis-base/utils/piecefunc"
 )
 
 const (
@@ -38,16 +39,62 @@ type Database struct {
 	onDrop  func()
 }
 
+// adjustCache scales down cache to match "real" RAM usage by process
+var adjustCache = piecefunc.NewFunc([]piecefunc.Dot{
+	{
+		X: 0,
+		Y: 16 * opt.KiB,
+	},
+	{
+		X: 12 * opt.MiB,
+		Y: 100 * opt.KiB,
+	},
+	{
+		X: 15 * opt.MiB,
+		Y: 1 * opt.MiB,
+	},
+	{
+		X: 47 * opt.MiB,
+		Y: 10 * opt.MiB,
+	},
+	{
+		X: 69 * opt.MiB,
+		Y: 14 * opt.MiB,
+	},
+	{
+		X: 88 * opt.MiB,
+		Y: 18 * opt.MiB,
+	},
+	{
+		X: 190 * opt.MiB,
+		Y: 40 * opt.MiB,
+	},
+	{
+		X: 350 * opt.MiB,
+		Y: 100 * opt.MiB,
+	},
+	{
+		X: 930 * opt.MiB,
+		Y: 300 * opt.MiB,
+	},
+	{
+		X: 3300 * opt.MiB,
+		Y: 1000 * opt.MiB,
+	},
+	{
+		X: 6400000 * opt.MiB,
+		Y: 2000000 * opt.MiB,
+	},
+})
+
 // New returns a wrapped LevelDB object. The namespace is the prefix that the
 // metrics reporting should use for surfacing internal stats.
 func New(path string, cache int, handles int, close func() error, drop func()) (*Database, error) {
 	// Ensure we have some minimal caching and file guarantees
-	if cache < minCache {
-		cache = minCache
-	}
 	if handles < minHandles {
 		handles = minHandles
 	}
+	cache = int(adjustCache(uint64(cache)))
 
 	// Open the db and recover any potential corruptions
 	db, err := leveldb.OpenFile(path, &opt.Options{

--- a/kvdb/leveldb/producer.go
+++ b/kvdb/leveldb/producer.go
@@ -9,15 +9,15 @@ import (
 )
 
 type Producer struct {
-	datadir  string
-	getCache func(string) int
+	datadir         string
+	getCacheFdLimit func(string) (int, int)
 }
 
 // NewProducer of level db.
-func NewProducer(datadir string, getCache func(string) int) kvdb.IterableDBProducer {
+func NewProducer(datadir string, getCacheFdLimit func(string) (int, int)) kvdb.IterableDBProducer {
 	return &Producer{
-		datadir:  datadir,
-		getCache: getCache,
+		datadir:         datadir,
+		getCacheFdLimit: getCacheFdLimit,
 	}
 }
 
@@ -52,7 +52,8 @@ func (p *Producer) OpenDB(name string) (kvdb.Store, error) {
 		_ = os.RemoveAll(path)
 	}
 
-	db, err := New(path, p.getCache(name), 0, nil, onDrop)
+	cache, fdlimit := p.getCacheFdLimit(name)
+	db, err := New(path, cache, fdlimit, nil, onDrop)
 	if err != nil {
 		return nil, err
 	}

--- a/kvdb/multidb/producer.go
+++ b/kvdb/multidb/producer.go
@@ -174,3 +174,24 @@ func (p *Producer) Flush(id []byte) error {
 	}
 	return nil
 }
+
+func (p *Producer) Initialize(dbNames []string, flushID []byte) ([]byte, error) {
+	for _, producer := range p.producers {
+		var err error
+		flushID, err = producer.Initialize(dbNames, flushID)
+		if err != nil {
+			return flushID, err
+		}
+	}
+	return flushID, nil
+}
+
+func (p *Producer) Close() error {
+	for _, producer := range p.producers {
+		err := producer.Close()
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/kvdb/multidb/verify.go
+++ b/kvdb/multidb/verify.go
@@ -22,7 +22,7 @@ func (p *Producer) verifyRecords(oldDBRecords map[DBLocator][]TableRecord) error
 
 func (p *Producer) getRecords() (map[DBLocator][]TableRecord, error) {
 	dbRecords := make(map[DBLocator][]TableRecord)
-	for typ, producer := range p.producers {
+	for typ, producer := range p.allProducers {
 		for _, name := range producer.Names() {
 			db, err := producer.OpenDB(name)
 			if err != nil {

--- a/kvdb/pebble/pebble.go
+++ b/kvdb/pebble/pebble.go
@@ -138,6 +138,11 @@ func (db *Database) AsyncFlush() error {
 	return err
 }
 
+// SyncFlush synchronously flushes the in-memory buffer to the disk.
+func (db *Database) SyncFlush() error {
+	return db.underlying.Flush()
+}
+
 // Has retrieves if a key is present in the key-value store.
 func (db *Database) Has(key []byte) (bool, error) {
 	_, closer, err := db.underlying.Get(key)
@@ -253,6 +258,12 @@ func bytesPrefix(prefix []byte) pebble.IterOptions {
 
 // Stat returns a particular internal stat of the database.
 func (db *Database) Stat(property string) (string, error) {
+	if property == "async_flush" {
+		return "", db.AsyncFlush()
+	}
+	if property == "sync_flush" {
+		return "", db.SyncFlush()
+	}
 	// only "leveldb." prefix is accessible using debug.chaindbProperty
 	if property == "leveldb.iostats" {
 		total := db.underlying.Metrics().Total()

--- a/kvdb/pebble/pebble.go
+++ b/kvdb/pebble/pebble.go
@@ -24,11 +24,11 @@ type Database struct {
 
 // New returns a wrapped LevelDB object. The namespace is the prefix that the
 // metrics reporting should use for surfacing internal stats.
-func New(path string, cache int, close func() error, drop func()) (*Database, error) {
+func New(path string, cache int, handles int, close func() error, drop func()) (*Database, error) {
 	db, err := pebble.Open(path, &pebble.Options{
 		Cache:                    pebble.NewCache(int64(cache / 2)), // default 8 MB
 		MemTableSize:             cache / 4,                         // default 4 MB
-		MaxOpenFiles:             1000,                              // default 1000
+		MaxOpenFiles:             handles,                           // default 1000
 		WALBytesPerSync:          0,                                 // default 0 (matches RocksDB = no background syncing)
 		MaxConcurrentCompactions: 3,                                 // default 1, important for big imports performance
 	})

--- a/kvdb/pebble/producer.go
+++ b/kvdb/pebble/producer.go
@@ -9,15 +9,15 @@ import (
 )
 
 type Producer struct {
-	datadir  string
-	getCache func(string) int
+	datadir         string
+	getCacheFdLimit func(string) (int, int)
 }
 
 // NewProducer of Pebble db.
-func NewProducer(datadir string, getCache func(string) int) kvdb.IterableDBProducer {
+func NewProducer(datadir string, getCacheFdLimit func(string) (int, int)) kvdb.IterableDBProducer {
 	return &Producer{
-		datadir:  datadir,
-		getCache: getCache,
+		datadir:         datadir,
+		getCacheFdLimit: getCacheFdLimit,
 	}
 }
 
@@ -52,7 +52,8 @@ func (p *Producer) OpenDB(name string) (kvdb.Store, error) {
 		_ = os.RemoveAll(path)
 	}
 
-	db, err := New(path, p.getCache(name), nil, onDrop)
+	cache, fdlimit := p.getCacheFdLimit(name)
+	db, err := New(path, cache, fdlimit, nil, onDrop)
 	if err != nil {
 		return nil, err
 	}

--- a/utils/fmtfilter/fmt_test.go
+++ b/utils/fmtfilter/fmt_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestCompileFilter(t *testing.T) {
 	_, err := CompileFilter("%d", "")
-	require.Error(t, err, "template ops for scanf don't match scanf ops")
+	require.NoError(t, err)
 	_, err = CompileFilter("%d", "%s")
 	require.Error(t, err, "template ops for scanf don't match scanf ops")
 	_, err = CompileFilter("%d%s", "%s")
@@ -16,7 +16,7 @@ func TestCompileFilter(t *testing.T) {
 	_, err = CompileFilter("dd%d%sdd", "dd%sss")
 	require.Error(t, err, "template ops for scanf don't match scanf ops")
 	_, err = CompileFilter("dd%d%sdd", "%%")
-	require.Error(t, err, "template ops for scanf don't match scanf ops")
+	require.NoError(t, err)
 
 	_, err = CompileFilter("%", "%s")
 	require.Error(t, err, "non-closed %")
@@ -39,6 +39,14 @@ func TestCompileFilter(t *testing.T) {
 	res, err := fn("qw123er")
 	require.NoError(t, err)
 	require.Equal(t, "ty123ui", res)
+
+	fn, err = CompileFilter("qw%d%2s123%%", "--%d__%s~~%%")
+	require.NoError(t, err)
+	res, err = fn("qw456AB123")
+	require.Error(t, err)
+	res, err = fn("qw456AB123%")
+	require.NoError(t, err)
+	require.Equal(t, "--456__AB~~%", res)
 
 	fn, err = CompileFilter("qw%d%2s123", "--%d__%s~~")
 	require.NoError(t, err)

--- a/utils/piecefunc/piecefunc.go
+++ b/utils/piecefunc/piecefunc.go
@@ -1,0 +1,80 @@
+package piecefunc
+
+import "math"
+
+const (
+	// DecimalUnit is used to define ratios with integers, it's 1.0
+	DecimalUnit = 1e6
+	maxVal      = math.MaxUint64/uint64(DecimalUnit) - 1
+)
+
+// Dot is a pair of numbers
+type Dot struct {
+	X uint64
+	Y uint64
+}
+
+type Func struct {
+	dots []Dot
+}
+
+func NewFunc(dots []Dot) func(x uint64) uint64 {
+	if len(dots) < 2 {
+		panic("too few dots")
+	}
+
+	var prevX uint64
+	for i, dot := range dots {
+		if i >= 1 && dot.X <= prevX {
+			panic("non monotonic X")
+		}
+		if dot.Y > maxVal {
+			panic("too large Y")
+		}
+		if dot.X > maxVal {
+			panic("too large X")
+		}
+		prevX = dot.X
+	}
+
+	return Func{
+		dots: dots,
+	}.Get
+}
+
+// Mul is multiplication of ratios with integer numbers
+func Mul(a, b uint64) uint64 {
+	return a * b / DecimalUnit
+}
+
+// Div is division of ratios with integer numbers
+func Div(a, b uint64) uint64 {
+	return a * DecimalUnit / b
+}
+
+// Get calculates f(x), where f is a piecewise linear function defined by the pieces
+func (f Func) Get(x uint64) uint64 {
+	if x < f.dots[0].X {
+		return f.dots[0].Y
+	}
+	if x > f.dots[len(f.dots)-1].X {
+		return f.dots[len(f.dots)-1].Y
+	}
+	// find a piece
+	p0 := len(f.dots) - 2
+	for i, piece := range f.dots {
+		if i >= 1 && i < len(f.dots)-1 && piece.X > x {
+			p0 = i - 1
+			break
+		}
+	}
+	// linearly interpolate
+	p1 := p0 + 1
+
+	x0, x1 := f.dots[p0].X, f.dots[p1].X
+	y0, y1 := f.dots[p0].Y, f.dots[p1].Y
+
+	ratio := Div(x-x0, x1-x0)
+
+	return Mul(y0, DecimalUnit-ratio) + Mul(y1, ratio)
+}

--- a/utils/piecefunc/piecefunc_test.go
+++ b/utils/piecefunc/piecefunc_test.go
@@ -1,0 +1,216 @@
+package piecefunc
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestConstFunc(t *testing.T) {
+	require := require.New(t)
+
+	var constF = NewFunc([]Dot{
+		{
+			X: 0.0 * DecimalUnit,
+			Y: 1.0 * DecimalUnit,
+		},
+		{
+			X: 10.0 * DecimalUnit,
+			Y: 1.0 * DecimalUnit,
+		},
+		{
+			X: 20.0 * DecimalUnit,
+			Y: 1.0 * DecimalUnit,
+		},
+		{
+			X: 0xFFFFFF * DecimalUnit,
+			Y: 1.0 * DecimalUnit,
+		},
+	})
+
+	for i, x := range []uint64{0, 1, 5, 10, 20, 0xFFFF, 0xFFFFFF} {
+		X := x * DecimalUnit
+		Y := constF(X)
+		require.Equal(uint64(DecimalUnit), Y, i)
+	}
+}
+
+func TestUp45Func(t *testing.T) {
+	require := require.New(t)
+
+	var up45F = NewFunc([]Dot{
+		{
+			X: 0.0 * DecimalUnit,
+			Y: 0.0 * DecimalUnit,
+		},
+		{
+			X: 10.0 * DecimalUnit,
+			Y: 10.0 * DecimalUnit,
+		},
+		{
+			X: 20.0 * DecimalUnit,
+			Y: 20.0 * DecimalUnit,
+		},
+		{
+			X: 0xFFFFFF * DecimalUnit,
+			Y: 21.0 * DecimalUnit,
+		},
+	})
+
+	for i, x := range []uint64{0, 1, 3, 5, 10, 20} {
+		X := x * DecimalUnit
+		Y := up45F(X)
+		require.Equal(X, Y, i)
+	}
+
+	for i, x := range []uint64{21, 0xFFFF, 0xFFFFFF} {
+		X := x * DecimalUnit
+		Y := up45F(X)
+		require.True(20.0*DecimalUnit <= Y && Y <= 21.0*DecimalUnit, i)
+	}
+}
+
+func TestDown45Func(t *testing.T) {
+	require := require.New(t)
+
+	var down45F = NewFunc([]Dot{
+		{
+			X: 0.0 * DecimalUnit,
+			Y: 20.0 * DecimalUnit,
+		},
+		{
+			X: 10.0 * DecimalUnit,
+			Y: 10.0 * DecimalUnit,
+		},
+		{
+			X: 20.0 * DecimalUnit,
+			Y: 0.0 * DecimalUnit,
+		},
+	})
+
+	for i, x := range []uint64{0, 1, 2, 5, 10, 20} {
+		X := x * DecimalUnit
+		Y := down45F(X)
+		require.Equal(20.0*DecimalUnit-X, Y, i)
+	}
+}
+
+func TestFuncCheck(t *testing.T) {
+	require := require.New(t)
+
+	require.Panics(func() {
+		// too few dots
+		_ = NewFunc([]Dot{
+			{
+				X: 0.0 * DecimalUnit,
+				Y: 20.0 * DecimalUnit,
+			},
+		})
+	})
+
+	require.Panics(func() {
+		// non monotonic X
+		_ = NewFunc([]Dot{
+			{
+				X: 0.0 * DecimalUnit,
+				Y: 20.0 * DecimalUnit,
+			},
+			{
+				X: 20.0 * DecimalUnit,
+				Y: 20.0 * DecimalUnit,
+			},
+			{
+				X: 10.0 * DecimalUnit,
+				Y: 20.0 * DecimalUnit,
+			},
+		})
+	})
+	require.Panics(func() {
+		// too large val
+		NewFunc([]Dot{
+			{
+				X: 0,
+				Y: 0,
+			},
+			{
+				X: maxVal + 1,
+				Y: 1,
+			},
+		})
+	})
+	require.Panics(func() {
+		// too large val
+		NewFunc([]Dot{
+			{
+				X: 0,
+				Y: 0,
+			},
+			{
+				X: 1,
+				Y: maxVal + 1,
+			},
+		})
+	})
+	require.Panics(func() {
+		// too large val
+		NewFunc([]Dot{
+			{
+				X: maxVal + 1,
+				Y: maxVal + 1,
+			},
+			{
+				X: maxVal + 2,
+				Y: maxVal + 2,
+			},
+		})
+	})
+}
+
+func TestCustomFunc(t *testing.T) {
+	require := require.New(t)
+
+	var f = NewFunc([]Dot{
+		{
+			X: 1,
+			Y: 0.0 * DecimalUnit,
+		},
+		{
+			X: 10.0 * DecimalUnit,
+			Y: 10.0 * DecimalUnit,
+		},
+		{
+			X: 20.0 * DecimalUnit,
+			Y: 40.0 * DecimalUnit,
+		},
+		{
+			X: 25.0 * DecimalUnit,
+			Y: 41.0 * DecimalUnit,
+		},
+		{
+			X: maxVal,
+			Y: maxVal,
+		},
+	})
+
+	require.Equal(uint64(0), f(0))
+	require.Equal(uint64(0), f(1))
+	require.Equal(uint64(0), f(10))
+	require.Equal(uint64(10), f(11))
+	require.Equal(uint64(4.99999*DecimalUnit), f(5.0*DecimalUnit))
+	require.Equal(uint64(10.0*DecimalUnit), f(10.0*DecimalUnit))
+	require.Equal(uint64(25.0*DecimalUnit), f(15.0*DecimalUnit))
+	require.Equal(uint64(34.0*DecimalUnit), f(18.0*DecimalUnit))
+	require.Equal(uint64(37.0*DecimalUnit), f(19.0*DecimalUnit))
+	require.Equal(uint64(37.3*DecimalUnit), f(19.1*DecimalUnit))
+	require.Equal(uint64(40.0*DecimalUnit), f(20.0*DecimalUnit))
+	require.Equal(uint64(40.4*DecimalUnit), f(22.0*DecimalUnit))
+	require.Equal(uint64(41*DecimalUnit), f(25.0*DecimalUnit))
+	require.Equal(uint64(250012.273351*DecimalUnit), f(250000.0*DecimalUnit))
+	require.Equal(uint64(2500011.987361*DecimalUnit), f(2500000.0*DecimalUnit))
+	require.Equal(uint64(maxVal-18446704-18446703), f(maxVal-18446704-16))
+	require.Equal(uint64(maxVal-18446704), f(maxVal-18446704-15))
+	require.Equal(uint64(maxVal-18446704), f(maxVal-1))
+	require.Equal(uint64(maxVal), f(maxVal))
+	require.Equal(uint64(maxVal), f(math.MaxUint64))
+}


### PR DESCRIPTION
- add FD limit configuration for leveldb and pebble DBs
- cache sizes for pebble and leveldb reflect RAM usage more closely
- add flagged producer as a lighter version of flushable producer for detection of abrupt stopping