### PR TITLE
Pebble - unref cache to prevent memory leaks

### DIFF
--- a/kvdb/pebble/pebble.go
+++ b/kvdb/pebble/pebble.go
@@ -76,12 +76,15 @@ var adjustCache = piecefunc.NewFunc([]piecefunc.Dot{
 // metrics reporting should use for surfacing internal stats.
 func New(path string, cache int, handles int, close func() error, drop func()) (*Database, error) {
 	cache = int(adjustCache(uint64(cache)))
+	c := pebble.NewCache(int64(cache * 2 / 3))
+	defer c.Unref()
+
 	db, err := pebble.Open(path, &pebble.Options{
-		Cache:                    pebble.NewCache(int64(cache * 2 / 3)), // default 8 MB
-		MemTableSize:             cache / 3,                             // default 4 MB
-		MaxOpenFiles:             handles,                               // default 1000
-		WALBytesPerSync:          0,                                     // default 0 (matches RocksDB = no background syncing)
-		MaxConcurrentCompactions: 3,                                     // default 1, important for big imports performance
+		Cache:                    c,
+		MemTableSize:             cache / 3, // default 4 MB
+		MaxOpenFiles:             handles,   // default 1000
+		WALBytesPerSync:          0,         // default 0 (matches RocksDB = no background syncing)
+		MaxConcurrentCompactions: 3,         // default 1, important for big imports performance
 	})
 
 	if err != nil {


### PR DESCRIPTION
Ensure correct Pebble cache allocation/deallocation.

From pebble source:
```
// NewCache creates a new cache of the specified size. Memory for the cache is
// allocated on demand, not during initialization. The cache is created with a
// reference count of 1. Each DB it is associated with adds a reference, so the
// creator of the cache should usually release their reference after the DB is
// created.
//
//   c := pebble.NewCache(...)
//   defer c.Unref()
//   d, err := pebble.Open(pebble.Options{Cache: c})`
```