### PR TITLE
New store for vecengine

### DIFF
--- a/abft/indexed_lachesis.go
+++ b/abft/indexed_lachesis.go
@@ -38,7 +38,7 @@ type DagIndexer interface {
 	Reset(validators *pos.Validators, db kvdb.FlushableKVStore, getEvent func(hash.Event) dag.Event)
 }
 
-// New creates IndexedLachesis instance.
+// NewIndexedLachesis creates IndexedLachesis instance.
 func NewIndexedLachesis(store *Store, input EventSource, dagIndexer DagIndexer, crit func(error), config Config) *IndexedLachesis {
 	p := &IndexedLachesis{
 		Lachesis:      NewLachesis(store, input, dagIndexer, crit, config),

--- a/abft/indexed_lachesis.go
+++ b/abft/indexed_lachesis.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Fantom-foundation/lachesis-base/inter/idx"
 	"github.com/Fantom-foundation/lachesis-base/inter/pos"
 	"github.com/Fantom-foundation/lachesis-base/kvdb"
+	"github.com/Fantom-foundation/lachesis-base/kvdb/flushable"
 	"github.com/Fantom-foundation/lachesis-base/lachesis"
 )
 
@@ -34,7 +35,7 @@ type DagIndexer interface {
 	Flush()
 	DropNotFlushed()
 
-	Reset(validators *pos.Validators, db kvdb.Store, getEvent func(hash.Event) dag.Event)
+	Reset(validators *pos.Validators, db kvdb.FlushableKVStore, getEvent func(hash.Event) dag.Event)
 }
 
 // New creates IndexedLachesis instance.
@@ -89,7 +90,7 @@ func (p *IndexedLachesis) Bootstrap(callback lachesis.ConsensusCallbacks) error 
 			if base.EpochDBLoaded != nil {
 				base.EpochDBLoaded(epoch)
 			}
-			p.dagIndexer.Reset(p.store.GetValidators(), p.store.epochTable.VectorIndex, p.input.GetEvent)
+			p.dagIndexer.Reset(p.store.GetValidators(), flushable.Wrap(p.store.epochTable.VectorIndex), p.input.GetEvent)
 		},
 	}
 	return p.Lachesis.BootstrapWithOrderer(callback, ordererCallbacks)

--- a/vecengine/vecflushable/backed_map.go
+++ b/vecengine/vecflushable/backed_map.go
@@ -58,7 +58,7 @@ func (w *backedMap) add(key string, val []byte) {
 	w.cache[key] = val
 	if len(w.cache) > lenBefore {
 		w.cacheIndex = append(w.cacheIndex, key)
-		w.cacheSizeEstimation += MapConst + 2*len(key) + len(val)
+		w.cacheSizeEstimation += mapMemEst(len(key), len(val))
 	}
 }
 
@@ -94,7 +94,7 @@ func (w *backedMap) unloadIfNecessary() error {
 		}
 
 		delete(w.cache, key)
-		removedEstimation += (2*len(key) + len(val))
+		removedEstimation += mapMemEst(len(key), len(val))
 		cutoff++
 
 		if removedEstimation >= w.evictionThreshold {

--- a/vecengine/vecflushable/backed_map.go
+++ b/vecengine/vecflushable/backed_map.go
@@ -1,0 +1,128 @@
+package vecflushable
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+
+	"github.com/Fantom-foundation/lachesis-base/kvdb"
+	"github.com/Fantom-foundation/lachesis-base/kvdb/batched"
+)
+
+// TestSizeLimit is used as the limit in unit-test of packages that use vecflushable
+const TestSizeLimit = 100000
+
+type backedMap struct {
+	cache               map[string][]byte
+	cacheIndex          []string
+	backup              kvdb.Store
+	sizeLimit           int
+	evictionThreshold   int
+	cacheSizeEstimation int
+}
+
+func newBackedMap(backup kvdb.Store, sizeLimit int, evictionThreshold int) *backedMap {
+	return &backedMap{
+		cache:             make(map[string][]byte),
+		cacheIndex:        []string{},
+		backup:            backup,
+		sizeLimit:         sizeLimit,
+		evictionThreshold: evictionThreshold,
+	}
+}
+
+func (w *backedMap) has(key []byte) (bool, error) {
+	if _, ok := w.cache[string(key)]; ok {
+		return true, nil
+	}
+	val, err := w.backup.Get(key)
+	if err != nil {
+		return false, err
+	}
+	return val != nil, nil
+}
+
+func (w *backedMap) get(key []byte) ([]byte, error) {
+	if val, ok := w.cache[string(key)]; ok {
+		return common.CopyBytes(val), nil
+	}
+	return w.backup.Get(key)
+}
+
+func (w *backedMap) close() error {
+	w.cache = nil
+	w.cacheIndex = nil
+	return w.backup.Close()
+}
+
+func (w *backedMap) add(key string, val []byte) {
+	lenBefore := len(w.cache)
+	w.cache[key] = val
+	if len(w.cache) > lenBefore {
+		w.cacheIndex = append(w.cacheIndex, key)
+		w.cacheSizeEstimation += MapConst + 2*len(key) + len(val)
+	}
+}
+
+func (w *backedMap) unloadIfNecessary() error {
+	if w.cacheSizeEstimation < w.sizeLimit {
+		return nil
+	}
+
+	batch := w.backup.NewBatch()
+	defer batch.Reset()
+
+	cutoff := 0
+	removedEstimation := 0
+	for _, key := range w.cacheIndex {
+		var err error
+
+		val, ok := w.cache[key]
+		if !ok {
+			return errInconsistent
+		}
+
+		err = batch.Put([]byte(key), val)
+		if err != nil {
+			return err
+		}
+
+		if batch.ValueSize() > kvdb.IdealBatchSize {
+			err = batch.Write()
+			if err != nil {
+				return err
+			}
+			batch.Reset()
+		}
+
+		delete(w.cache, key)
+		removedEstimation += (2*len(key) + len(val))
+		cutoff++
+
+		if removedEstimation >= w.evictionThreshold {
+			break
+		}
+	}
+
+	err := batch.Write()
+	if err != nil {
+		return err
+	}
+
+	w.cacheIndex = w.cacheIndex[cutoff:]
+	w.cacheSizeEstimation -= removedEstimation
+
+	return nil
+}
+
+func (w *backedMap) deleteAll() {
+	w.cache = make(map[string][]byte)
+	w.cacheIndex = []string{}
+	w.cacheSizeEstimation = 0
+
+	wrappedDB := batched.Wrap(w.backup)
+	it := wrappedDB.NewIterator(nil, nil)
+	for it.Next() {
+		wrappedDB.Delete(it.Key())
+	}
+	it.Release()
+	wrappedDB.Flush()
+}

--- a/vecengine/vecflushable/backed_map.go
+++ b/vecengine/vecflushable/backed_map.go
@@ -59,7 +59,7 @@ func (w *backedMap) add(key string, val []byte) {
 // mayUnload evicts and flushes one batch of data
 func (w *backedMap) mayUnload() error {
 	for w.memSize > w.maxMemSize {
-		err := w.unload()
+		err := w.unload(kvdb.IdealBatchSize)
 		if err != nil {
 			return err
 		}
@@ -68,7 +68,7 @@ func (w *backedMap) mayUnload() error {
 	return nil
 }
 
-func (w *backedMap) unload() error {
+func (w *backedMap) unload(toUnload int) error {
 	batch := w.backup.NewBatch()
 	defer batch.Reset()
 
@@ -86,7 +86,7 @@ func (w *backedMap) unload() error {
 			w.memSize = 0
 		}
 
-		if batch.ValueSize() > kvdb.IdealBatchSize {
+		if batch.ValueSize() >= toUnload {
 			break
 		}
 	}

--- a/vecengine/vecflushable/vecflushable.go
+++ b/vecengine/vecflushable/vecflushable.go
@@ -29,24 +29,15 @@ type VecFlushable struct {
 	modified   map[string][]byte
 	underlying backedMap
 	memSize    int
-	onDrop     func()
 }
 
 func Wrap(parent kvdb.Store, sizeLimit int) *VecFlushable {
 	if parent == nil {
 		panic("nil parent")
 	}
-	return WrapWithDrop(parent, sizeLimit, parent.Drop)
-}
-
-func WrapWithDrop(parent kvdb.Store, sizeLimit int, drop func()) *VecFlushable {
-	if parent == nil {
-		panic("nil parent")
-	}
 	return &VecFlushable{
 		modified:   make(map[string][]byte),
 		underlying: *newBackedMap(parent, sizeLimit),
-		onDrop:     drop,
 	}
 }
 
@@ -126,12 +117,7 @@ func (w *VecFlushable) Close() error {
 }
 
 func (w *VecFlushable) Drop() {
-	if w.modified != nil {
-		panic("close db first")
-	}
-	if w.onDrop != nil {
-		w.onDrop()
-	}
+	panic(errNotImplemented)
 }
 
 /* Some methods are not implemented and panic when called */

--- a/vecengine/vecflushable/vecflushable.go
+++ b/vecengine/vecflushable/vecflushable.go
@@ -3,8 +3,9 @@ package vecflushable
 import (
 	"errors"
 
-	"github.com/Fantom-foundation/lachesis-base/kvdb"
 	"github.com/ethereum/go-ethereum/common"
+
+	"github.com/Fantom-foundation/lachesis-base/kvdb"
 )
 
 var (
@@ -13,9 +14,13 @@ var (
 	errInconsistent   = errors.New("vecflushable - inconsistent db")
 )
 
-// MapConst is an approximation of the number of extra bytes used by native go
+// mapConst is an approximation of the number of extra bytes used by native go
 // maps when adding an item to a map.
-const MapConst = 100
+const mapConst = 100
+
+func mapMemEst(keyS, valueS int) int {
+	return mapConst + keyS + valueS
+}
 
 // VecFlushable is a fast, append only, Flushable intended for the vecengine.
 // It does not implement all of the Flushable interface, just what is needed by
@@ -76,7 +81,7 @@ func (w *VecFlushable) Put(key []byte, value []byte) error {
 		return errors.New("vecflushable: key or value is nil")
 	}
 	w.modified[string(key)] = common.CopyBytes(value)
-	w.sizeEstimation += MapConst + len(key) + len(value)
+	w.sizeEstimation += mapMemEst(len(key), len(value))
 	return nil
 }
 
@@ -156,4 +161,3 @@ func (w *VecFlushable) Compact(start []byte, limit []byte) error {
 func (w *VecFlushable) NewBatch() kvdb.Batch {
 	panic(errNotImplemented)
 }
-

--- a/vecengine/vecflushable/vecflushable.go
+++ b/vecengine/vecflushable/vecflushable.go
@@ -11,7 +11,6 @@ import (
 var (
 	errClosed         = errors.New("vecflushable - database closed")
 	errNotImplemented = errors.New("vecflushable - not implemented")
-	errInconsistent   = errors.New("vecflushable - inconsistent db")
 )
 
 // mapConst is an approximation of the number of extra bytes used by native go

--- a/vecengine/vecflushable/vecflushable.go
+++ b/vecengine/vecflushable/vecflushable.go
@@ -45,7 +45,7 @@ func WrapWithDrop(parent kvdb.Store, sizeLimit int, drop func()) *VecFlushable {
 	}
 	return &VecFlushable{
 		modified:   make(map[string][]byte),
-		underlying: *newBackedMap(parent, sizeLimit, sizeLimit/2),
+		underlying: *newBackedMap(parent, sizeLimit),
 		onDrop:     drop,
 	}
 }
@@ -98,7 +98,7 @@ func (w *VecFlushable) Flush() error {
 		return errClosed
 	}
 
-	w.underlying.unloadIfNecessary()
+	w.underlying.mayUnload()
 
 	for key, val := range w.modified {
 		w.underlying.add(key, val)

--- a/vecengine/vecflushable/vecflushable.go
+++ b/vecengine/vecflushable/vecflushable.go
@@ -1,0 +1,159 @@
+package vecflushable
+
+import (
+	"errors"
+
+	"github.com/Fantom-foundation/lachesis-base/kvdb"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+var (
+	errClosed         = errors.New("vecflushable - database closed")
+	errNotImplemented = errors.New("vecflushable - not implemented")
+	errInconsistent   = errors.New("vecflushable - inconsistent db")
+)
+
+// MapConst is an approximation of the number of extra bytes used by native go
+// maps when adding an item to a map.
+const MapConst = 100
+
+// VecFlushable is a fast, append only, Flushable intended for the vecengine.
+// It does not implement all of the Flushable interface, just what is needed by
+// the vecengine.
+type VecFlushable struct {
+	modified       map[string][]byte
+	underlying     backedMap
+	sizeEstimation int
+	onDrop         func()
+}
+
+func Wrap(parent kvdb.Store, sizeLimit int) *VecFlushable {
+	if parent == nil {
+		panic("nil parent")
+	}
+	return WrapWithDrop(parent, sizeLimit, parent.Drop)
+}
+
+func WrapWithDrop(parent kvdb.Store, sizeLimit int, drop func()) *VecFlushable {
+	if parent == nil {
+		panic("nil parent")
+	}
+	return &VecFlushable{
+		modified:   make(map[string][]byte),
+		underlying: *newBackedMap(parent, sizeLimit, sizeLimit/2),
+		onDrop:     drop,
+	}
+}
+
+func (w *VecFlushable) clearModified() {
+	w.modified = make(map[string][]byte)
+	w.sizeEstimation = 0
+}
+
+func (w *VecFlushable) Has(key []byte) (bool, error) {
+	if w.modified == nil {
+		return false, errClosed
+	}
+	_, ok := w.modified[string(key)]
+	if ok {
+		return true, nil
+	}
+	return w.underlying.has(key)
+}
+
+func (w *VecFlushable) Get(key []byte) ([]byte, error) {
+	if w.modified == nil {
+		return nil, errClosed
+	}
+	if val, ok := w.modified[string(key)]; ok {
+		return common.CopyBytes(val), nil
+	}
+	return w.underlying.get(key)
+}
+
+func (w *VecFlushable) Put(key []byte, value []byte) error {
+	if value == nil || key == nil {
+		return errors.New("vecflushable: key or value is nil")
+	}
+	w.modified[string(key)] = common.CopyBytes(value)
+	w.sizeEstimation += MapConst + len(key) + len(value)
+	return nil
+}
+
+func (w *VecFlushable) NotFlushedPairs() int {
+	return len(w.modified)
+}
+
+func (w *VecFlushable) NotFlushedSizeEst() int {
+	return w.sizeEstimation
+}
+
+func (w *VecFlushable) Flush() error {
+	if w.modified == nil {
+		return errClosed
+	}
+
+	w.underlying.unloadIfNecessary()
+
+	for key, val := range w.modified {
+		w.underlying.add(key, val)
+	}
+
+	w.clearModified()
+
+	return nil
+}
+
+func (w *VecFlushable) DropNotFlushed() {
+	w.clearModified()
+}
+
+func (w *VecFlushable) DeleteAll() {
+	w.DropNotFlushed()
+	w.underlying.deleteAll()
+}
+
+func (w *VecFlushable) Close() error {
+	if w.modified == nil {
+		return errClosed
+	}
+	w.DropNotFlushed()
+	w.modified = nil
+	return w.underlying.close()
+}
+
+func (w *VecFlushable) Drop() {
+	if w.modified != nil {
+		panic("close db first")
+	}
+	if w.onDrop != nil {
+		w.onDrop()
+	}
+}
+
+/* Some methods are not implemented and panic when called */
+
+func (w *VecFlushable) Delete(key []byte) error {
+	panic(errNotImplemented)
+}
+
+func (w *VecFlushable) GetSnapshot() (kvdb.Snapshot, error) {
+	panic(errNotImplemented)
+}
+
+func (w *VecFlushable) NewIterator(prefix []byte, start []byte) kvdb.Iterator {
+	panic(errNotImplemented)
+}
+
+func (w *VecFlushable) Stat(property string) (string, error) {
+	panic(errNotImplemented)
+}
+
+func (w *VecFlushable) Compact(start []byte, limit []byte) error {
+	panic(errNotImplemented)
+}
+
+func (w *VecFlushable) NewBatch() kvdb.Batch {
+	panic(errNotImplemented)
+}
+

--- a/vecengine/vecflushable/vecflushable.go
+++ b/vecengine/vecflushable/vecflushable.go
@@ -98,7 +98,10 @@ func (w *VecFlushable) Flush() error {
 		return errClosed
 	}
 
-	w.underlying.mayUnload()
+	err := w.underlying.mayUnload()
+	if err != nil {
+		return err
+	}
 
 	for key, val := range w.modified {
 		w.underlying.add(key, val)
@@ -111,11 +114,6 @@ func (w *VecFlushable) Flush() error {
 
 func (w *VecFlushable) DropNotFlushed() {
 	w.clearModified()
-}
-
-func (w *VecFlushable) DeleteAll() {
-	w.DropNotFlushed()
-	w.underlying.deleteAll()
 }
 
 func (w *VecFlushable) Close() error {

--- a/vecfc/forkless_cause_test.go
+++ b/vecfc/forkless_cause_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/Fantom-foundation/lachesis-base/inter/idx"
 	"github.com/Fantom-foundation/lachesis-base/inter/pos"
 	"github.com/Fantom-foundation/lachesis-base/kvdb/memorydb"
+	"github.com/Fantom-foundation/lachesis-base/vecengine/vecflushable"
 )
 
 func tCrit(err error) { panic(err) }
@@ -51,7 +52,7 @@ func benchForklessCauseProcess(b *testing.B, dagAscii string, idx *int) {
 	}
 
 	vi := NewIndex(tCrit, LiteConfig())
-	vi.Reset(validators, memorydb.New(), getEvent)
+	vi.Reset(validators, vecflushable.Wrap(memorydb.New(), vecflushable.TestSizeLimit), getEvent)
 
 	_, _, named := tdag.ASCIIschemeForEach(dagAscii, tdag.ForEachEvent{
 		Process: func(e dag.Event, name string) {
@@ -142,7 +143,7 @@ func testForklessCaused(t *testing.T, dagAscii string) {
 	}
 
 	vi := NewIndex(tCrit, LiteConfig())
-	vi.Reset(validators, memorydb.New(), getEvent)
+	vi.Reset(validators, vecflushable.Wrap(memorydb.New(), vecflushable.TestSizeLimit), getEvent)
 
 	_, _, named := tdag.ASCIIschemeForEach(dagAscii, tdag.ForEachEvent{
 		Process: func(e dag.Event, name string) {
@@ -460,7 +461,7 @@ func TestForklessCausedRandom(t *testing.T) {
 	}
 
 	vi := NewIndex(tCrit, LiteConfig())
-	vi.Reset(validators, memorydb.New(), getEvent)
+	vi.Reset(validators, vecflushable.Wrap(memorydb.New(), vecflushable.TestSizeLimit), getEvent)
 
 	// push
 	for _, e := range ordered {
@@ -542,7 +543,7 @@ func TestRandomForksSanity(t *testing.T) {
 	}
 
 	vi := NewIndex(tCrit, LiteConfig())
-	vi.Reset(validators, memorydb.New(), getEvent)
+	vi.Reset(validators, vecflushable.Wrap(memorydb.New(), vecflushable.TestSizeLimit), getEvent)
 
 	// Many forks from each node in large graph, so probability of not seeing a fork is negligible
 	events := tdag.ForEachRandFork(nodes, cheaters, 300, 4, 30, nil, tdag.ForEachEvent{
@@ -669,7 +670,7 @@ func TestRandomForks(t *testing.T) {
 			}
 
 			vi := NewIndex(tCrit, LiteConfig())
-			vi.Reset(validators, memorydb.New(), getEvent)
+			vi.Reset(validators, vecflushable.Wrap(memorydb.New(), vecflushable.TestSizeLimit), getEvent)
 
 			_ = tdag.ForEachRandFork(nodes, cheaters, test.eventsNum, test.parentsNum, test.forksNum, r, tdag.ForEachEvent{
 				Process: func(e dag.Event, name string) {

--- a/vecfc/index_test.go
+++ b/vecfc/index_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/Fantom-foundation/lachesis-base/inter/dag/tdag"
 	"github.com/Fantom-foundation/lachesis-base/inter/pos"
 	"github.com/Fantom-foundation/lachesis-base/kvdb/memorydb"
+	"github.com/Fantom-foundation/lachesis-base/vecengine/vecflushable"
 )
 
 var (
@@ -52,11 +53,11 @@ func BenchmarkIndex_Add(b *testing.B) {
 	}
 
 	vecClock := NewIndex(func(err error) { panic(err) }, LiteConfig())
-	vecClock.Reset(validators, memorydb.New(), getEvent)
+	vecClock.Reset(validators, vecflushable.Wrap(memorydb.New(), vecflushable.TestSizeLimit), getEvent)
 
 	for i := 0; i < b.N; i++ {
 		b.StopTimer()
-		vecClock.Reset(validators, memorydb.New(), getEvent)
+		vecClock.Reset(validators, vecflushable.Wrap(memorydb.New(), vecflushable.TestSizeLimit), getEvent)
 		b.StartTimer()
 		for _, e := range ordered {
 			err := vecClock.Add(e)


### PR DESCRIPTION
Continuation of #58
- reindexing of epoch events after restart is handled externally by go-opera